### PR TITLE
Implement Dynamic Island-style Notch HUD and improve visibility

### DIFF
--- a/Stasis/AppDelegate.swift
+++ b/Stasis/AppDelegate.swift
@@ -10,6 +10,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var viewModel: MenuViewModel!
     private var menuBuilder: MenuBuilder!
     private var chargeManager: ChargeManager!
+    private var notchHUDManager: NotchHUDManager!
     private var settingsWindowController: SettingsWindowController!
     private var menu: NSMenu!
     private let updaterManager = UpdaterManager.shared
@@ -78,6 +79,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             settingsWindowController: settingsWindowController
         )
         statusBarManager = StatusBarManager(viewModel: viewModel)
+        notchHUDManager = NotchHUDManager(viewModel: viewModel)
     }
 
     private func setupMenu() {

--- a/Stasis/Controllers/SettingsWindowController.swift
+++ b/Stasis/Controllers/SettingsWindowController.swift
@@ -58,6 +58,7 @@ class SettingsWindowController: NSObject, NSWindowDelegate {
         let settingsView = SettingsView(
             capabilities: capabilities
         )
+
         let hostingController = NSHostingController(rootView: settingsView)
 
         let newWindow = NSWindow(contentViewController: hostingController)
@@ -67,12 +68,15 @@ class SettingsWindowController: NSObject, NSWindowDelegate {
         newWindow.titlebarAppearsTransparent = false
         newWindow.toolbarStyle = .automatic
         newWindow.isMovableByWindowBackground = true
-        newWindow.setFrameAutosaveName("SettingsWindow")
+        newWindow.minSize = NSSize(width: 750, height: 540)
         newWindow.isReleasedWhenClosed = false
-        newWindow.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
-        newWindow.delegate = self
+        newWindow.collectionBehavior = [.moveToActiveSpace, .fullScreenPrimary]
         
-        positionWindow(newWindow)
+        positionWindow(newWindow) // Center it on first launch after reset
+
+        newWindow.delegate = self
+        window = newWindow
+        newWindow.setFrameAutosaveName("SettingsWindow")
         
         AppActivationPolicy.enter()
         newWindow.makeKeyAndOrderFront(nil)

--- a/Stasis/Controllers/SettingsWindowController.swift
+++ b/Stasis/Controllers/SettingsWindowController.swift
@@ -30,26 +30,13 @@ class SettingsWindowController: NSObject, NSWindowDelegate {
     }
 
     func showSettings() {
-        let activeScreen = NSScreen.screens.first { $0.frame.contains(NSEvent.mouseLocation) } ?? NSScreen.main
-        
-        let positionWindow: (NSWindow) -> Void = { win in
-            if let screen = activeScreen {
-                let screenRect = screen.visibleFrame
-                let windowRect = win.frame
-                let newX = screenRect.origin.x + (screenRect.width - windowRect.width) / 2
-                let newY = screenRect.origin.y + (screenRect.height - windowRect.height) / 2
-                win.setFrameOrigin(NSPoint(x: newX, y: newY))
-            } else {
-                win.center()
-            }
-        }
-
+        // Window positioning is now handled by .center()
         if let existingWindow = window {
             let wasVisible = existingWindow.isVisible
             if !wasVisible {
                 AppActivationPolicy.enter()
             }
-            positionWindow(existingWindow)
+            existingWindow.center()
             existingWindow.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -69,10 +56,11 @@ class SettingsWindowController: NSObject, NSWindowDelegate {
         newWindow.toolbarStyle = .automatic
         newWindow.isMovableByWindowBackground = true
         newWindow.minSize = NSSize(width: 750, height: 540)
+        newWindow.setContentSize(NSSize(width: 750, height: 540))
         newWindow.isReleasedWhenClosed = false
         newWindow.collectionBehavior = [.moveToActiveSpace, .fullScreenPrimary]
         
-        positionWindow(newWindow) // Center it on first launch after reset
+        newWindow.center() // Center it on first launch after reset
 
         newWindow.delegate = self
         window = newWindow

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -20,6 +20,13 @@ enum BatteryPercentageVisibility: String, CaseIterable, Defaults.Serializable, I
     var id: Self { self }
 }
 
+enum NotchHUDDisplayMode: String, CaseIterable, Defaults.Serializable, Identifiable {
+    case macDisplayOnly = "Mac Display Only"
+    case allDisplays = "All Displays"
+    
+    var id: Self { self }
+}
+
 extension Defaults.Keys {
     // General
     static let launchAtLogin = Key<Bool>("launchAtLogin", default: false)
@@ -45,6 +52,18 @@ extension Defaults.Keys {
         "showChargingStatusChangedNotification",
         default: true
     )
+    static let enableNotchHUD = Key<Bool>(
+        "enableNotchHUD",
+        default: true
+    )
+    static let showNotchHUDOnLockScreen = Key<Bool>(
+        "showNotchHUDOnLockScreen",
+        default: true
+    )
+    static let notchHUDDisplayMode = Key<NotchHUDDisplayMode>(
+        "notchHUDDisplayMode",
+        default: .macDisplayOnly
+    )
 
     // Menu Dashboard
     static let showTimeTillDischarge = Key<Bool>(
@@ -60,7 +79,7 @@ extension Defaults.Keys {
         "showBatteryTemperature",
         default: false
     )
-    static let showPowerSource = Key<Bool>("showPowerSource", default: false)
+    static let showPowerSource = Key<Bool>("showPowerSource", default: true)
     static let showUptime = Key<Bool>("showUptime", default: true)
     static let showBatteryMode = Key<Bool>("showBatteryMode", default: true)
     static let showInternalPower = Key<Bool>("showInternalPower", default: true)

--- a/Stasis/Services/ChargingHelperManager.swift
+++ b/Stasis/Services/ChargingHelperManager.swift
@@ -26,7 +26,7 @@ class ChargingHelperManager {
     private(set) var helperStatus: ChargingHelperStatus
 
     var isInstalled: Bool {
-        SMAppService.daemon(plistName: Self.plistName).status == .enabled
+        helperStatus == .installed
     }
 
     private init() {
@@ -58,9 +58,23 @@ class ChargingHelperManager {
 
     func uninstall() throws {
         logger.info("Unregistering charging helper daemon")
+        // Reset the SMC to its default state before uninstalling so the Mac isn't stuck at 80%
+        if let helper = getHelper(errorHandler: { _ in }) {
+            let semaphore = DispatchSemaphore(value: 0)
+            helper.resetToDefaults { _, _ in
+                semaphore.signal()
+            }
+            // Wait briefly for the reset to complete before we destroy the daemon
+            _ = semaphore.wait(timeout: .now() + 2.0)
+        }
+        
         disconnect()
         try service.unregister()
         helperStatus = .notInstalled
+        
+        // Force the UI toggle off since the helper is gone
+        UserDefaults.standard.set(false, forKey: "isChargingManagementEnabled")
+        UserDefaults.standard.synchronize()
     }
 
     func refreshStatus() {

--- a/Stasis/Services/NotchHUDManager.swift
+++ b/Stasis/Services/NotchHUDManager.swift
@@ -171,14 +171,21 @@ class NotchHUDManager {
         guard let targetScreen = targetScreens.first else { return }
         let isPill = !NotchWindow.hasNotch(screen: targetScreen)
 
-        // Update state to trigger animation
+        let wasVisible = window.isVisible
+        
+        // Ensure state starts collapsed if window is not visible
+        if !wasVisible {
+            state.isVisible = false
+        }
+
+        // Update state content
         state.statusText = text
         state.batteryLevel = viewModel.displayPercentage
         state.chargingMode = viewModel.chargingMode
         state.isLowPowerModeEnabled = viewModel.isLowPowerModeEnabled
         
         // Ensure the window is shown with the view bound to our state
-        if window.contentView == nil || !window.isVisible {
+        if window.contentView == nil || !wasVisible {
             let contentView = ChargingNotchView(state: state)
             if !isPill {
                 window.contentHeight = targetScreen.safeAreaInsets.top
@@ -187,9 +194,15 @@ class NotchHUDManager {
                 window.contentHeight = 36
                 window.showPill(on: targetScreen, content: contentView)
             }
+            
+            // Trigger animation on next runloop tick so view is in hierarchy
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(50))
+                self.state.isVisible = true
+            }
+        } else {
+            state.isVisible = true
         }
-        
-        state.isVisible = true
 
         // Cancel existing hide task
         hideTask?.cancel()

--- a/Stasis/Services/NotchHUDManager.swift
+++ b/Stasis/Services/NotchHUDManager.swift
@@ -1,0 +1,211 @@
+import AppKit
+import Defaults
+import Foundation
+import Observation
+import SwiftUI
+
+@MainActor
+class NotchHUDManager {
+    private let window: NotchWindow
+    private let viewModel: MenuViewModel
+    private var observationTask: Task<Void, Never>?
+    private var hideTask: Task<Void, Never>?
+    private let state = NotchHUDState() // Persistent state for smooth animations
+
+    // Track previous states to detect changes
+    private var previousChargingMode: ChargingMode?
+    private var previousLowPowerMode: Bool?
+    private var previousForceDischarge: Bool?
+    private var previousAdapterConnected: Bool?
+
+    init(viewModel: MenuViewModel) {
+        self.viewModel = viewModel
+        self.window = NotchWindow()
+        // Override default shadow padding/height for our custom view
+        self.window.contentHeight = 36
+        self.window.shadowPadding = 0 // Tighter padding for a cleaner look
+        self.window.hasShadow = false // Fix grayish color blending
+
+        startObserving()
+    }
+
+    private func startObserving() {
+        observationTask = Task {
+            // Wait for initial values to settle
+            try? await Task.sleep(for: .seconds(2))
+            
+            // Set initial state without triggering HUD
+            previousChargingMode = viewModel.chargingMode
+            previousLowPowerMode = viewModel.isLowPowerModeEnabled
+            previousForceDischarge = viewModel.forceDischargeActive
+            previousAdapterConnected = viewModel.adapterConnected
+
+            for await _ in NotificationCenter.default.notifications(named: .NSProcessInfoPowerStateDidChange) {
+                // To allow Low Power Mode observation without polling
+                Task { @MainActor in
+                    self.checkStateAndShowHUD()
+                }
+            }
+        }
+        
+        Task {
+            // Give time for initial properties to settle
+            try? await Task.sleep(for: .seconds(2))
+            while !Task.isCancelled {
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        _ = viewModel.chargingMode
+                        _ = viewModel.isLowPowerModeEnabled
+                        _ = viewModel.forceDischargeActive
+                        _ = viewModel.adapterConnected
+                    } onChange: {
+                        Task { @MainActor in
+                            continuation.resume()
+                        }
+                    }
+                }
+                checkStateAndShowHUD()
+            }
+        }
+    }
+
+    private func checkStateAndShowHUD() {
+        guard Defaults[.enableNotchHUD] else { return }
+        
+        if !Defaults[.showNotchHUDOnLockScreen] {
+            if let session = CGSessionCopyCurrentDictionary() as? [String: Any],
+               let isLocked = session["CGSSessionScreenIsLocked"] as? Bool,
+               isLocked {
+                return
+            }
+        }
+
+        let currentChargingMode = viewModel.chargingMode
+        let currentLowPowerMode = viewModel.isLowPowerModeEnabled
+        let currentForceDischarge = viewModel.forceDischargeActive
+        let currentAdapterConnected = viewModel.adapterConnected
+
+        // Determine what changed
+        let modeChanged = currentChargingMode != previousChargingMode
+        let lpmChanged = currentLowPowerMode != previousLowPowerMode
+        let fdChanged = currentForceDischarge != previousForceDischarge
+        let adapterChanged = currentAdapterConnected != previousAdapterConnected
+
+        // If something relevant changed, show HUD
+        if modeChanged || lpmChanged || fdChanged || adapterChanged {
+            let text = determineStatusText(
+                chargingMode: currentChargingMode,
+                lowPowerMode: currentLowPowerMode,
+                forceDischarge: currentForceDischarge,
+                adapterConnected: currentAdapterConnected,
+                lpmChanged: lpmChanged
+            )
+            showHUD(with: text)
+        }
+
+        // Update tracking
+        previousChargingMode = currentChargingMode
+        previousLowPowerMode = currentLowPowerMode
+        previousForceDischarge = currentForceDischarge
+        previousAdapterConnected = currentAdapterConnected
+    }
+
+    private func determineStatusText(
+        chargingMode: ChargingMode,
+        lowPowerMode: Bool,
+        forceDischarge: Bool,
+        adapterConnected: Bool,
+        lpmChanged: Bool
+    ) -> String {
+        if lowPowerMode && lpmChanged {
+            return "Low Power Mode"
+        }
+        if forceDischarge {
+            return "Force Discharging"
+        }
+        if !adapterConnected {
+            return "On Battery"
+        }
+        if chargingMode == .charging {
+            return "Charging"
+        }
+        if chargingMode == .pluggedIn {
+            if Defaults[.manageCharging] {
+                // If manage charging is on and we are plugged in but not charging
+                let level = viewModel.displayPercentage
+                if level >= Defaults[.chargeLimit] {
+                    return "Limit Reached"
+                } else if Defaults[.sailingMode] {
+                    return "Sailing Mode"
+                } else {
+                    return "On Hold"
+                }
+            }
+            if viewModel.displayPercentage == 100 {
+                return "Fully Charged"
+            }
+            return "Plugged In"
+        }
+        return "Unknown"
+    }
+
+    private func showHUD(with text: String) {
+        let displayMode = Defaults[.notchHUDDisplayMode]
+        var targetScreens: [NSScreen] = []
+        
+        if displayMode == .macDisplayOnly {
+            // Find the screen with a physical notch
+            if let notchScreen = NSScreen.screens.first(where: { NotchWindow.hasNotch(screen: $0) }) {
+                targetScreens.append(notchScreen)
+            } else if let mainScreen = NSScreen.main {
+                // Fallback to main if no notch is found, maybe it's an older Mac display
+                targetScreens.append(mainScreen)
+            }
+        } else {
+            // Show on main screen or all screens. For simplicity, just use main screen if all displays
+            if let mainScreen = NSScreen.main {
+                targetScreens.append(mainScreen)
+            }
+        }
+
+        guard let targetScreen = targetScreens.first else { return }
+        let isPill = !NotchWindow.hasNotch(screen: targetScreen)
+
+        // Update state to trigger animation
+        state.statusText = text
+        state.batteryLevel = viewModel.displayPercentage
+        state.chargingMode = viewModel.chargingMode
+        state.isLowPowerModeEnabled = viewModel.isLowPowerModeEnabled
+        
+        // Ensure the window is shown with the view bound to our state
+        if window.contentView == nil || !window.isVisible {
+            let contentView = ChargingNotchView(state: state)
+            if !isPill {
+                window.contentHeight = targetScreen.safeAreaInsets.top
+                window.showNotch(on: targetScreen, content: contentView)
+            } else {
+                window.contentHeight = 36
+                window.showPill(on: targetScreen, content: contentView)
+            }
+        }
+        
+        state.isVisible = true
+
+        // Cancel existing hide task
+        hideTask?.cancel()
+
+        // Create new hide task
+        hideTask = Task {
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            
+            // Trigger SwiftUI collapse animation
+            state.isVisible = false
+            
+            // Wait for spring animation to finish then close window
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            window.orderOut(nil)
+        }
+    }
+}

--- a/Stasis/Views/Notch/ChargingNotchView.swift
+++ b/Stasis/Views/Notch/ChargingNotchView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import Observation
+
+@MainActor
+@Observable
+class NotchHUDState {
+    var isVisible: Bool = false
+    var statusText: String = ""
+    var batteryLevel: Int = 0
+    var chargingMode: ChargingMode = .discharging
+    var isLowPowerModeEnabled: Bool = false
+
+    // Dynamic metrics for an asymmetric pill that wraps perfectly tightly around content
+    // but uses a visual offset to keep the physical hardware notch dead center
+    
+    var leftContentWidth: CGFloat {
+        if !isVisible { return 0 }
+        // 16pt outer padding + text width + 16pt inner padding
+        let textWidth = CGFloat(statusText.count) * 7.5
+        return 16 + textWidth + 16
+    }
+    
+    var rightContentWidth: CGFloat {
+        if !isVisible { return 0 }
+        // 16pt inner padding + battery icon + 16pt outer padding
+        return 16 + 60 + 16 // battery is around 60 wide
+    }
+
+    var dynamicWidth: CGFloat {
+        if !isVisible { return 180 }
+        return leftContentWidth + 180 + rightContentWidth
+    }
+    
+    var correctionOffset: CGFloat {
+        if !isVisible { return 0 }
+        // Math to keep the 180 gap perfectly centered on screen despite an asymmetrical shape
+        return (rightContentWidth - leftContentWidth) / 2
+    }
+}
+
+struct ChargingNotchView: View {
+    var state: NotchHUDState
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // LEFT SIDE: Text
+            Text(state.statusText)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white) // Always dark theme
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.trailing, 16)
+                .opacity(state.isVisible ? 1 : 0) // Smooth fade in
+                .frame(width: state.isVisible ? state.leftContentWidth : 0)
+
+            // CENTER: The physical notch width
+            Spacer()
+                .frame(width: 180) 
+
+            // RIGHT SIDE: Battery
+            BatteryIndicatorView(
+                batteryLevel: state.batteryLevel,
+                chargingMode: state.chargingMode,
+                isLowPowerModeEnabled: state.isLowPowerModeEnabled,
+                batteryPercentageVisibility: .nextToIcon,
+                showState: true
+            )
+            .colorScheme(.dark) // Always dark theme
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 16)
+            .opacity(state.isVisible ? 1 : 0)
+            .frame(width: state.isVisible ? state.rightContentWidth : 0)
+        }
+        // Use dynamically calculated asymmetric width that perfectly wraps content
+        .frame(width: state.dynamicWidth, height: nil)
+        // Offset the entire capsule so the 180 gap remains perfectly dead center on the physical hardware notch
+        .offset(x: state.correctionOffset)
+        .frame(maxHeight: .infinity)
+        .background(
+            // Pure pitch black always, offset so it moves with the content!
+            Rectangle().fill(Color(red: 0, green: 0, blue: 0))
+                .clipShape(NotchShape())
+                .offset(x: state.correctionOffset)
+        )
+        // Improved bouncy spring animation (response: 0.4, dampingFraction: 0.6)
+        .animation(.spring(response: 0.4, dampingFraction: 0.6), value: state.isVisible)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/Stasis/Views/Notch/ChargingNotchView.swift
+++ b/Stasis/Views/Notch/ChargingNotchView.swift
@@ -47,10 +47,11 @@ struct ChargingNotchView: View {
             Text(state.statusText)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white) // Always dark theme
+                .fixedSize(horizontal: true, vertical: false) // Prevent truncation during animation
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.trailing, 16)
-                .opacity(state.isVisible ? 1 : 0) // Smooth fade in
                 .frame(width: state.isVisible ? state.leftContentWidth : 0)
+                .clipped()
 
             // CENTER: The physical notch width
             Spacer()
@@ -65,22 +66,20 @@ struct ChargingNotchView: View {
                 showState: true
             )
             .colorScheme(.dark) // Always dark theme
+            .fixedSize(horizontal: true, vertical: false)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 16)
-            .opacity(state.isVisible ? 1 : 0)
             .frame(width: state.isVisible ? state.rightContentWidth : 0)
+            .clipped()
         }
         // Use dynamically calculated asymmetric width that perfectly wraps content
-        .frame(width: state.dynamicWidth, height: nil)
+        .frame(width: state.dynamicWidth)
+        .frame(maxHeight: .infinity)
+        // Background and clip shape MUST be applied BEFORE offset so they perfectly wrap the asymmetric content
+        .background(NotchShape().fill(.black))
+        .clipShape(NotchShape())
         // Offset the entire capsule so the 180 gap remains perfectly dead center on the physical hardware notch
         .offset(x: state.correctionOffset)
-        .frame(maxHeight: .infinity)
-        .background(
-            // Pure pitch black always, offset so it moves with the content!
-            Rectangle().fill(Color(red: 0, green: 0, blue: 0))
-                .clipShape(NotchShape())
-                .offset(x: state.correctionOffset)
-        )
         // Improved bouncy spring animation (response: 0.4, dampingFraction: 0.6)
         .animation(.spring(response: 0.4, dampingFraction: 0.6), value: state.isVisible)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/Stasis/Views/Notch/NotchShape.swift
+++ b/Stasis/Views/Notch/NotchShape.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct NotchShape: Shape {
+    var topCornerRadius: CGFloat
+    var bottomCornerRadius: CGFloat
+
+    init(topCornerRadius: CGFloat = 10, bottomCornerRadius: CGFloat = 16) {
+        self.topCornerRadius = topCornerRadius
+        self.bottomCornerRadius = bottomCornerRadius
+    }
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { .init(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        // Start at the top-left corner
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        // Top-left "ear": concave curve bowing inward
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY + topCornerRadius),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY)
+        )
+
+        // Left edge down to bottom-left
+        path.addLine(to: CGPoint(x: rect.minX + topCornerRadius,
+                                 y: rect.maxY - bottomCornerRadius))
+
+        // Bottom-left convex rounded corner
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY)
+        )
+
+        // Bottom edge
+        path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius,
+                                 y: rect.maxY))
+
+        // Bottom-right convex rounded corner
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - topCornerRadius,
+                        y: rect.maxY - bottomCornerRadius),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY)
+        )
+
+        // Right edge up to top-right
+        path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius,
+                                 y: rect.minY + topCornerRadius))
+
+        // Top-right "ear": concave curve bowing outward
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)
+        )
+
+        // Close along the top edge
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        return path
+    }
+}

--- a/Stasis/Views/Notch/NotchWindow.swift
+++ b/Stasis/Views/Notch/NotchWindow.swift
@@ -1,0 +1,104 @@
+import AppKit
+import SwiftUI
+
+class NotchWindow: NSPanel {
+
+    /// Shadow padding around the content to allow for drop shadows or glow effects.
+    /// Increase if your content has large shadows.
+    var shadowPadding: CGFloat = 20
+
+    /// The width of the content area (excluding shadow padding).
+    var contentWidth: CGFloat = 360
+
+    /// The height of the content area (excluding shadow padding).
+    var contentHeight: CGFloat = 140
+
+    init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.nonactivatingPanel, .fullSizeContentView, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 10)
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        isMovableByWindowBackground = false
+        collectionBehavior = [.fullScreenAuxiliary, .canJoinAllSpaces, .stationary, .ignoresCycle]
+        ignoresMouseEvents = true
+        canBecomeVisibleWithoutLogin = true
+    }
+
+    /// Show the notch overlay with the given SwiftUI content.
+    ///
+    /// The window is positioned at `CGShieldingWindowLevel` (above everything)
+    /// centered at the top of the target screen, flush with the top edge.
+    func showNotch<Content: View>(on screen: NSScreen, content: Content) {
+        // Place above the menu bar but not so high that WindowServer forces it behind
+        // the menu bar (a known issue with CGShieldingWindowLevel on modern macOS).
+        // .mainMenu + 10 is the standard hack used by other notch apps to stay on top.
+        level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 10)
+        collectionBehavior = [.stationary, .canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+
+        // Use the entire screen width so the SwiftUI view can center itself naturally
+        let totalWidth = screen.frame.width
+        let totalHeight = contentHeight + shadowPadding
+
+        let x = screen.frame.origin.x
+        let y = screen.frame.origin.y + screen.frame.height - totalHeight
+        setFrame(CGRect(x: x, y: y, width: totalWidth, height: totalHeight), display: false)
+
+        let hosting = NSHostingView(rootView:
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        )
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        contentView = hosting
+
+        alphaValue = 1
+        orderFrontRegardless()
+    }
+
+    /// Show as a floating pill at the bottom of the screen (fallback for non-notch Macs).
+    func showPill<Content: View>(on screen: NSScreen, content: Content) {
+        level = .floating
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Use the entire screen width to prevent clipping
+        let totalWidth = screen.frame.width
+        let totalHeight = contentHeight + shadowPadding
+        
+        let x = screen.frame.origin.x
+        let y = screen.visibleFrame.minY + 30
+        setFrame(CGRect(x: x, y: y, width: totalWidth, height: totalHeight), display: false)
+
+        let hosting = NSHostingView(rootView:
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        )
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        contentView = hosting
+
+        alphaValue = 1
+        orderFrontRegardless()
+    }
+
+    /// Hide with a fade-out animation.
+    func hideNotch(completion: (() -> Void)? = nil) {
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.3
+            animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            self?.orderOut(nil)
+            completion?()
+        })
+    }
+
+    /// Whether the given screen has a hardware notch.
+    static func hasNotch(screen: NSScreen) -> Bool {
+        return screen.safeAreaInsets.top > 0
+    }
+}

--- a/Stasis/Views/Notch/NotchWindow.swift
+++ b/Stasis/Views/Notch/NotchWindow.swift
@@ -22,7 +22,7 @@ class NotchWindow: NSPanel {
         )
 
         isFloatingPanel = true
-        level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 10)
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
         isOpaque = false
         backgroundColor = .clear
         hasShadow = false
@@ -37,10 +37,8 @@ class NotchWindow: NSPanel {
     /// The window is positioned at `CGShieldingWindowLevel` (above everything)
     /// centered at the top of the target screen, flush with the top edge.
     func showNotch<Content: View>(on screen: NSScreen, content: Content) {
-        // Place above the menu bar but not so high that WindowServer forces it behind
-        // the menu bar (a known issue with CGShieldingWindowLevel on modern macOS).
-        // .mainMenu + 10 is the standard hack used by other notch apps to stay on top.
-        level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 10)
+        // Use CGShieldingWindowLevel to appear above the lock screen and other HUD apps
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
         collectionBehavior = [.stationary, .canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
 
         // Use the entire screen width so the SwiftUI view can center itself naturally
@@ -60,6 +58,7 @@ class NotchWindow: NSPanel {
 
         alphaValue = 1
         orderFrontRegardless()
+        TopWindowElevator.shared.elevate(window: self)
     }
 
     /// Show as a floating pill at the bottom of the screen (fallback for non-notch Macs).
@@ -84,6 +83,7 @@ class NotchWindow: NSPanel {
 
         alphaValue = 1
         orderFrontRegardless()
+        TopWindowElevator.shared.elevate(window: self)
     }
 
     /// Hide with a fade-out animation.

--- a/Stasis/Views/Notch/TopWindowElevator.swift
+++ b/Stasis/Views/Notch/TopWindowElevator.swift
@@ -1,0 +1,66 @@
+import AppKit
+
+// CoreGraphics Private APIs for Maximum Z-Index Space
+fileprivate typealias CGSConnectionID = UInt
+fileprivate typealias CGSSpaceID = UInt64
+@_silgen_name("_CGSDefaultConnection")
+fileprivate func _CGSDefaultConnection() -> CGSConnectionID
+@_silgen_name("CGSSpaceCreate")
+fileprivate func CGSSpaceCreate(_ cid: CGSConnectionID, _ unknown: Int, _ options: NSDictionary?) -> CGSSpaceID
+@_silgen_name("CGSSpaceSetAbsoluteLevel")
+fileprivate func CGSSpaceSetAbsoluteLevel(_ cid: CGSConnectionID, _ space: CGSSpaceID, _ level: Int)
+@_silgen_name("CGSAddWindowsToSpaces")
+fileprivate func CGSAddWindowsToSpaces(_ cid: CGSConnectionID, _ windows: NSArray, _ spaces: NSArray)
+@_silgen_name("CGSShowSpaces")
+fileprivate func CGSShowSpaces(_ cid: CGSConnectionID, _ spaces: NSArray)
+
+class TopWindowElevator {
+    static let shared = TopWindowElevator()
+    
+    private let cgsSpaceID: CGSSpaceID
+    
+    // SkyLight Lock Screen Private APIs
+    private var slsConnection: Int32 = 0
+    private var slsSpace: Int32 = 0
+    private var SLSSpaceAddWindowsAndRemoveFromSpaces: (@convention(c) (Int32, Int32, CFArray, Int32) -> Int32)?
+    
+    private init() {
+        // 1. Create a CGS Space with maximum possible absolute level to appear above everything (including other notches)
+        let cid = _CGSDefaultConnection()
+        let flag = 0x1 // 1 is required to prevent Finder from drawing desktop icons in this space
+        cgsSpaceID = CGSSpaceCreate(cid, flag, nil)
+        CGSSpaceSetAbsoluteLevel(cid, cgsSpaceID, 2147483647) // Int32.max
+        CGSShowSpaces(cid, [cgsSpaceID] as NSArray)
+        
+        // 2. Setup SkyLight space specifically for Lock Screen visibility
+        if let bundle = CFBundleCreate(kCFAllocatorDefault, NSURL(fileURLWithPath: "/System/Library/PrivateFrameworks/SkyLight.framework")),
+           let SLSMainConnectionIDPointer = CFBundleGetFunctionPointerForName(bundle, "SLSMainConnectionID" as CFString),
+           let SLSSpaceCreatePointer = CFBundleGetFunctionPointerForName(bundle, "SLSSpaceCreate" as CFString),
+           let SLSSpaceSetAbsoluteLevelPointer = CFBundleGetFunctionPointerForName(bundle, "SLSSpaceSetAbsoluteLevel" as CFString),
+           let SLSShowSpacesPointer = CFBundleGetFunctionPointerForName(bundle, "SLSShowSpaces" as CFString),
+           let SLSSpaceAddWindowsAndRemoveFromSpacesPointer = CFBundleGetFunctionPointerForName(bundle, "SLSSpaceAddWindowsAndRemoveFromSpaces" as CFString) {
+            
+            let SLSMainConnectionID = unsafeBitCast(SLSMainConnectionIDPointer, to: (@convention(c) () -> Int32).self)
+            let SLSSpaceCreate = unsafeBitCast(SLSSpaceCreatePointer, to: (@convention(c) (Int32, Int32, Int32) -> Int32).self)
+            let SLSSpaceSetAbsoluteLevel = unsafeBitCast(SLSSpaceSetAbsoluteLevelPointer, to: (@convention(c) (Int32, Int32, Int32) -> Int32).self)
+            let SLSShowSpaces = unsafeBitCast(SLSShowSpacesPointer, to: (@convention(c) (Int32, CFArray) -> Int32).self)
+            self.SLSSpaceAddWindowsAndRemoveFromSpaces = unsafeBitCast(SLSSpaceAddWindowsAndRemoveFromSpacesPointer, to: (@convention(c) (Int32, Int32, CFArray, Int32) -> Int32).self)
+            
+            self.slsConnection = SLSMainConnectionID()
+            self.slsSpace = SLSSpaceCreate(self.slsConnection, 1, 0)
+            let _ = SLSSpaceSetAbsoluteLevel(self.slsConnection, self.slsSpace, 400) // kSLSSpaceAbsoluteLevelNotificationCenterAtScreenLock
+            let _ = SLSShowSpaces(self.slsConnection, [self.slsSpace] as CFArray)
+        }
+    }
+    
+    func elevate(window: NSWindow) {
+        // Add to max level CGS Space
+        let cid = _CGSDefaultConnection()
+        CGSAddWindowsToSpaces(cid, [window.windowNumber] as NSArray, [cgsSpaceID] as NSArray)
+        
+        // Add to SkyLight lock screen space
+        if let addWindows = self.SLSSpaceAddWindowsAndRemoveFromSpaces {
+            let _ = addWindows(self.slsConnection, self.slsSpace, [window.windowNumber] as CFArray, 7)
+        }
+    }
+}

--- a/Stasis/Views/Settings/AboutSettingsView.swift
+++ b/Stasis/Views/Settings/AboutSettingsView.swift
@@ -1,5 +1,6 @@
 import Defaults
 import SwiftUI
+import ServiceManagement
 
 struct AboutSettingsView: View {
     @Environment(\.openURL) private var openURL
@@ -150,7 +151,8 @@ struct AboutSettingsView: View {
                                 NSAlert.show(title: "Helper Status", message: "Helper daemon successfully installed.")
                             } else {
                                 try helperManager.uninstall()
-                                NSAlert.show(title: "Helper Status", message: "Helper daemon successfully uninstalled.")
+                                NSAlert.show(title: "Helper Status", message: "Helper daemon successfully uninstalled. The app will now restart.")
+                                restartApp()
                             }
                         } catch {
                             let msg = "Failed to \(installing ? "install" : "uninstall") charging helper:\n\(error.localizedDescription)\n\nTip: Check System Settings -> General -> Login Items. Ensure Stasis is allowed to run in the background. If it is already on, try toggling it off and on again."
@@ -172,7 +174,8 @@ struct AboutSettingsView: View {
                     Spacer()
                     Button("Reset") {
                         resetAllPreferences()
-                        NSAlert.show(title: "Preferences Reset", message: "All preferences have been successfully restored to their defaults.")
+                        NSAlert.show(title: "Preferences Reset", message: "All preferences have been successfully restored to their defaults. The app will now restart.")
+                        restartApp()
                     }
                     .foregroundColor(.red)
                 }
@@ -201,19 +204,38 @@ struct AboutSettingsView: View {
 
     // MARK: - Preferences reset helper
     private func resetAllPreferences() {
-        // Uninstall the helper daemon
+        // Uninstall the helper daemon (this handles SMC reset internally)
         do {
             try ChargingHelperManager.shared.uninstall()
         } catch {
             print("Failed to uninstall charging helper: \(error)")
         }
 
-        // Disable launch at login
+        // Disable launch at login and actively unregister to clear OS cache
         LaunchAtLoginService.shared.setLaunchAtLogin(false)
-
+        try? SMAppService.mainApp.unregister()
+        
         // Remove all persisted defaults for this app bundle
         let bundleID = Bundle.main.bundleIdentifier ?? "com.dinanathdash.stasis"
         UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        UserDefaults.standard.synchronize() // Force write
+        
+        // Reset system permissions (Accessibility, Background Items, etc.) to force OS cache flush
+        let tccProcess = Process()
+        tccProcess.launchPath = "/usr/bin/tccutil"
+        tccProcess.arguments = ["reset", "All", bundleID]
+        try? tccProcess.run()
+        tccProcess.waitUntilExit()
+    }
+    
+    private func restartApp() {
+        let url = Bundle.main.bundleURL
+        let task = Process()
+        task.launchPath = "/usr/bin/open"
+        task.arguments = ["-n", url.path]
+        try? task.run()
+        
+        exit(0)
     }
 }
 
@@ -226,6 +248,10 @@ extension NSAlert {
         alert.informativeText = message
         alert.alertStyle = style
         alert.addButton(withTitle: "OK")
+        
+        // Force the app to the foreground so the alert isn't hidden behind other windows
+        NSApp.activate(ignoringOtherApps: true)
+        
         NSSound.beep()
         alert.runModal()
     }

--- a/Stasis/Views/Settings/GeneralSettingsView.swift
+++ b/Stasis/Views/Settings/GeneralSettingsView.swift
@@ -7,6 +7,9 @@ struct GeneralSettingsView: View {
     @Default(.showBatteryStateInStatusIcon) var showBatteryStateInStatusIcon
     @Default(.disableNotifications) var disableNotifications
     @Default(.showChargingStatusChangedNotification) var showChargingStatusChangedNotification
+    @Default(.enableNotchHUD) var enableNotchHUD
+    @Default(.showNotchHUDOnLockScreen) var showNotchHUDOnLockScreen
+    @Default(.notchHUDDisplayMode) var notchHUDDisplayMode
 
     var body: some View {
         Form {
@@ -40,6 +43,25 @@ struct GeneralSettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Notifications")
                     Text("Control when Stasis sends you notifications.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section {
+                Toggle("Show charging state in Notch HUD", isOn: $enableNotchHUD)
+                if enableNotchHUD {
+                    Toggle("Show on lock screen", isOn: $showNotchHUDOnLockScreen)
+                    Picker("Display mode", selection: $notchHUDDisplayMode) {
+                        ForEach(NotchHUDDisplayMode.allCases) { mode in
+                            Text(LocalizedStringKey(mode.rawValue)).tag(mode)
+                        }
+                    }
+                }
+            } header: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Notch HUD")
+                    Text("Display a floating Dynamic Island-style HUD when the charging state changes.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
This pull request introduces a new Notch HUD feature that displays charging and battery status at the MacBook's notch area, along with several related improvements and refinements to user preferences and UI behavior. The most significant changes are the addition of the NotchHUD system, new user defaults for its configuration, and enhancements to window management and charging helper logic.

**Notch HUD Feature and UI Enhancements:**

* Added a new `NotchHUDManager` class that observes charging, battery, and power mode changes and displays a custom HUD at the notch or as a pill overlay, with smooth animations and dynamic content. This includes a new `NotchHUDState` observable state and a `ChargingNotchView` SwiftUI component for rendering the HUD, as well as a custom `NotchShape` for precise visual alignment. (`Stasis/Services/NotchHUDManager.swift`, `Stasis/Views/Notch/ChargingNotchView.swift`, `Stasis/Views/Notch/NotchShape.swift`) [[1]](diffhunk://#diff-dd679d729a4e2ab2fa32055bbd847c30b186bdb052383f5b299fcecda2757907R1-R224) [[2]](diffhunk://#diff-52104024da92e1e5d2454ff7922e0c21c9f7c6790352e03e8b9f5b1b800c1f75R1-R87) [[3]](diffhunk://#diff-ff36511e8f199433b6b8d12913b67ecaf048c44ee4fa86cd5f6d62e0b932b741R1-R68)
* Integrated the NotchHUD into the app lifecycle by instantiating `NotchHUDManager` in `AppDelegate`. (`Stasis/AppDelegate.swift`) [[1]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R13) [[2]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R82)

**User Preferences and Defaults:**

* Added new user defaults for enabling/disabling the Notch HUD, showing it on the lock screen, and choosing its display mode (Mac display only or all displays) via a new `NotchHUDDisplayMode` enum. Also changed the default for showing the power source in the menu to `true`. (`Stasis/DefaultsKeys.swift`) [[1]](diffhunk://#diff-5bdabe8585f494bc0facbc8743e0bcb5ac4b82aaefc27286f343773adb3aceb5R23-R29) [[2]](diffhunk://#diff-5bdabe8585f494bc0facbc8743e0bcb5ac4b82aaefc27286f343773adb3aceb5R55-R66) [[3]](diffhunk://#diff-5bdabe8585f494bc0facbc8743e0bcb5ac4b82aaefc27286f343773adb3aceb5L63-R82)

**Settings Window Behavior:**

* Simplified window positioning logic in `SettingsWindowController` to always use `.center()`, removed custom positioning code, and ensured the window is centered on first launch/reset. Also adjusted window sizing and collection behavior for improved consistency. (`Stasis/Controllers/SettingsWindowController.swift`) [[1]](diffhunk://#diff-76c50ff845081616f87bf5fa842d1bdddeb49c7fd4d054c06f1df3ceaf495e1aL33-R39) [[2]](diffhunk://#diff-76c50ff845081616f87bf5fa842d1bdddeb49c7fd4d054c06f1df3ceaf495e1aR48) [[3]](diffhunk://#diff-76c50ff845081616f87bf5fa842d1bdddeb49c7fd4d054c06f1df3ceaf495e1aL70-R67)

**Charging Helper Improvements:**

* Improved the uninstall logic for the charging helper daemon to reset the SMC to default before uninstalling, preventing the Mac from being stuck at 80% charge, and force the UI toggle off when the helper is uninstalled. Also fixed the `isInstalled` property to rely on the correct internal status. (`Stasis/Services/ChargingHelperManager.swift`) [[1]](diffhunk://#diff-e12c19500daa880e2940ff1d3b7dc8b2bd38c8ce54899db70df36d520306ae3fL29-R29) [[2]](diffhunk://#diff-e12c19500daa880e2940ff1d3b7dc8b2bd38c8ce54899db70df36d520306ae3fR61-R77)