### PR TITLE
Add Significant Energy Apps monitor with dashboard toggle and menu

### DIFF
--- a/Stasis/AppDelegate.swift
+++ b/Stasis/AppDelegate.swift
@@ -10,12 +10,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var menuBuilder: MenuBuilder!
     private var chargeManager: ChargeManager!
     private var calibrationManager: CalibrationManager!
+    private var significantEnergyService: SignificantEnergyService!
     private var notchHUDManager: NotchHUDManager!
     private var settingsWindowController: SettingsWindowController!
     private var menu: NSMenu!
     private let updaterManager = UpdaterManager.shared
     private var settingsObservation: Task<Void, Never>?
     private var adapterObservation: Task<Void, Never>?
+    private var significantEnergyObservation: Task<Void, Never>?
     private var isMenuOpen = false
     private var needsMenuRebuild = false
 
@@ -79,9 +81,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         await batteryService.loadCapabilities()
         chargeManager = ChargeManager(batteryService: batteryService)
         calibrationManager = CalibrationManager(batteryService: batteryService, chargeManager: chargeManager)
+        significantEnergyService = SignificantEnergyService()
         viewModel = MenuViewModel(
             batteryService: batteryService,
-            chargeManager: chargeManager
+            chargeManager: chargeManager,
+            significantEnergyService: significantEnergyService
         )
         settingsWindowController = SettingsWindowController(
             capabilities: batteryService.deviceCapabilities
@@ -122,7 +126,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                     .showPowerDistribution,
                     .showOutputPortsText, .outputVisualizationMode,
                     .manageCharging, .showAdvancedChargingControls,
-                    .appLanguage
+                    .appLanguage, .showSignificantEnergyApps
                 ],
                 initial: false
             ) {
@@ -137,6 +141,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 await withCheckedContinuation { continuation in
                     withObservationTracking {
                         _ = self.viewModel.adapterConnected
+                    } onChange: {
+                        Task { @MainActor in
+                            continuation.resume()
+                        }
+                    }
+                }
+            }
+        }
+
+        significantEnergyObservation = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.rebuildMenu()
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        _ = self.significantEnergyService.apps
                     } onChange: {
                         Task { @MainActor in
                             continuation.resume()

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -225,6 +225,10 @@ extension Defaults.Keys {
         "showAdvancedChargingControls",
         default: false
     )
+    static let showSignificantEnergyApps = Key<Bool>(
+        "showSignificantEnergyApps",
+        default: true
+    )
 
     // Charging
     static let manageCharging = Key<Bool>("manageCharging", default: false)

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1,6 +1,113 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "%@ W": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ W"
+          }
+        }
+      }
+    },
     "%lld": {
       "localizations": {
         "de": {
@@ -236,7 +343,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1秒"
           }
         },
         "zh-Hans": {
@@ -248,49 +355,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 秒"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 секунда"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 seconde"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 saniye"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 sekunda"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 sekunda"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 giây"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1초"
           }
         },
         "fr": {
@@ -302,19 +409,19 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 secondo"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 segundo"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 second"
+            "value": "1 segundo"
           }
         }
       }
@@ -342,7 +449,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10秒"
           }
         },
         "zh-Hans": {
@@ -354,49 +461,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 秒"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 секунд"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 seconden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 saniye"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 sekund"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 sekúnd"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 giây"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10초"
           }
         },
         "fr": {
@@ -408,19 +515,19 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 secondi"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 segundos"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "10 seconds"
+            "value": "10 segundos"
           }
         }
       }
@@ -448,7 +555,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2秒"
           }
         },
         "zh-Hans": {
@@ -460,49 +567,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 秒"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 секунды"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 seconden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 saniye"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 sekundi"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 sekundy"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 giây"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2초"
           }
         },
         "fr": {
@@ -514,19 +621,19 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 secondi"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 segundos"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 seconds"
+            "value": "2 segundos"
           }
         }
       }
@@ -554,7 +661,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3秒"
           }
         },
         "zh-Hans": {
@@ -566,49 +673,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 秒"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 секунды"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 seconden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 saniye"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 sekunde"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 sekundy"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 giây"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3초"
           }
         },
         "fr": {
@@ -620,19 +727,19 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 secondi"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 segundos"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "3 seconds"
+            "value": "3 segundos"
           }
         }
       }
@@ -660,7 +767,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5秒"
           }
         },
         "zh-Hans": {
@@ -672,49 +779,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 秒"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 секунд"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 seconden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 saniye"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 sekund"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 sekúnd"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 giây"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5초"
           }
         },
         "fr": {
@@ -726,19 +833,19 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 secondi"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 segundos"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "5 seconds"
+            "value": "5 segundos"
           }
         }
       }
@@ -1379,6 +1486,113 @@
         }
       }
     },
+    "All applications are running efficiently": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Anwendungen laufen effizient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las aplicaciones funcionan de forma eficiente"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las aplicaciones funcionan de forma eficiente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les applications fonctionnent de manière efficace"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutte le applicazioni funzionano in modo efficiente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのアプリケーションが効率的に動作しています"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 응용 프로그램이 효율적으로 실행 중입니다"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle applicaties werken efficiënt"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os aplicativos estão executando eficientemente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas as aplicações estão a funcionar de forma eficiente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все приложения работают эффективно"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Všetky aplikácie pracujú efektívne"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vse aplikacije delujejo učinkovito"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm uygulamalar verimli bir şekilde çalışıyor"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tất cả các ứng dụng đang chạy hiệu quả"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有应用程序运行高效"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有應用程式均高效率運作"
+          }
+        }
+      }
+    },
     "Always": {
       "localizations": {
         "de": {
@@ -1587,6 +1801,113 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aprove o Stasis em Configurações do Sistema → Itens de Início para continuar."
+          }
+        }
+      }
+    },
+    "Apps using significant energy": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps mit erheblichem Energieverbrauch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que usan mucha energía"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que usan mucha energía"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps gourmandes en énergie"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App che usano molta energia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エネルギーを著しく消費しているアプリ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에너지를 많이 사용하는 앱"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps die veel energie verbruiken"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps usando energia significativa"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que usam muita energia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложения со значительным расходом энергии"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikácie s významnou spotrebou energie"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikacije z veliko porabo energije"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Önemli miktarda enerji harcayan uygulamalar"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ứng dụng dùng nhiều năng lượng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显著消耗电能的应用程序"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "耗電量顯著的應用程式"
           }
         }
       }
@@ -7957,6 +8278,113 @@
         }
       }
     },
+    "Energy Impact": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Energieauswirkungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impacto energético"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impacto energético"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impact énergétique"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impatto energetico"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エネルギー影響"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에너지 영향"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Energie-impact"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impacto energético"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impacto energético"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Энерговоздействие"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Energetický vplyv"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vpliv na energijo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enerji Etkisi"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mức độ ảnh hưởng năng lượng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "能耗影响"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "能源衝擊"
+          }
+        }
+      }
+    },
     "English": {
       "localizations": {
         "de": {
@@ -11139,6 +11567,113 @@
         }
       }
     },
+    "No Significant Energy Apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Apps mit erheblichem Energieverbrauch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna app usa mucha energía"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna app usa mucha energía"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune app gourmande en énergie"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna app usa molta energia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エネルギーを著しく消費しているアプリはありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에너지를 많이 사용하는 앱 없음"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen apps die veel energie verbruiken"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum app usando energia significativa"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma app a usar muita energia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет приложений со значительным расходом энергии"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Žiadne aplikácie s významnou spotrebou energie"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ni aplikacij z veliko porabo energije"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Önemli Miktarda Enerji Harcayan Uygulama Yok"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có ứng dụng dùng nhiều năng lượng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无显著消耗电能的应用程序"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有耗電量顯著的應用程式"
+          }
+        }
+      }
+    },
     "Notch HUD": {
       "localizations": {
         "de": {
@@ -13494,7 +14029,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "設定をリセット"
           }
         },
         "zh-Hans": {
@@ -13506,49 +14041,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "重設偏好設定"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Сбросить настройки"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Herstel voorkeuren"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Tercihleri sıfırla"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Ponastavi nastavitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Obnoviť predvoľby"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Đặt lại tùy chọn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "환경설정 재설정"
           }
         },
         "fr": {
@@ -13560,7 +14095,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor definições"
+            "value": "Reimposta preferenze"
           }
         },
         "pt-PT": {
@@ -13600,7 +14135,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "すべての設定をリセット"
           }
         },
         "zh-Hans": {
@@ -13612,49 +14147,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "重設所有偏好設定"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Сбросить все настройки"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Herstel alle voorkeuren"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Tüm tercihleri sıfırla"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Ponastavi vse nastavitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Obnoviť všetky predvoľby"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Đặt lại tất cả tùy chọn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "모든 환경설정 재설정"
           }
         },
         "fr": {
@@ -13666,7 +14201,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor todas as definições"
+            "value": "Reimposta tutte le preferenze"
           }
         },
         "pt-PT": {
@@ -14952,6 +15487,113 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mostrar energia de saída"
+          }
+        }
+      }
+    },
+    "Significant Energy Apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps mit erheblichem Energieverbrauch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que usan mucha energía"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que usan mucha energía"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps gourmandes en énergie"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App che usano molta energia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エネルギーを著しく消費しているアプリ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에너지를 많이 사용하는 앱"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps die veel energie verbruiken"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps usando energia significativa"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que usam muita energia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложения со значительным расходом энергии"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikácie s významnou spotrebou energie"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikacije z veliko porabo energije"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Önemli Miktarda Enerji Harcayan Uygulamalar"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ứng dụng dùng nhiều năng lượng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显著消耗电能的应用程序"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "耗電量顯著的應用程式"
           }
         }
       }

--- a/Stasis/Models/SignificantEnergyApp.swift
+++ b/Stasis/Models/SignificantEnergyApp.swift
@@ -1,0 +1,22 @@
+import AppKit
+import Foundation
+
+struct SignificantEnergyApp: Identifiable, Equatable, Sendable {
+    let id: pid_t
+    let pid: pid_t
+    let name: String
+    let bundleIdentifier: String?
+    let powerScore: Double
+    let icon: NSImage?
+
+    static func == (lhs: SignificantEnergyApp, rhs: SignificantEnergyApp) -> Bool {
+        lhs.id == rhs.id && lhs.powerScore == rhs.powerScore
+    }
+
+    @MainActor
+    func activate() {
+        if let app = NSRunningApplication(processIdentifier: pid) {
+            app.activate()
+        }
+    }
+}

--- a/Stasis/Services/SignificantEnergyService.swift
+++ b/Stasis/Services/SignificantEnergyService.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Defaults
+import Foundation
+import Observation
+import os.log
+
+@MainActor
+@Observable
+class SignificantEnergyService {
+    private(set) var apps: [SignificantEnergyApp] = []
+
+    private let threshold: Double = 1.0
+    private var openMenuTask: Task<Void, Never>?
+    private let logger = Logger(
+        subsystem: "com.dinanathdash.stasis",
+        category: "SignificantEnergyService"
+    )
+
+    init() {}
+
+    func startOpenMenuPolling() {
+        stopOpenMenuPolling()
+        openMenuTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refresh()
+                try? await Task.sleep(for: .seconds(3))
+            }
+        }
+    }
+
+    func stopOpenMenuPolling() {
+        openMenuTask?.cancel()
+        openMenuTask = nil
+    }
+
+    func refresh() async {
+        guard Defaults[.showSignificantEnergyApps] else {
+            self.apps = []
+            return
+        }
+        let pidPowers = await fetchTopPowerMetrics()
+        let filteredApps = filterAndBuildApps(from: pidPowers)
+        self.apps = filteredApps
+    }
+
+    private func fetchTopPowerMetrics() async -> [(pid_t, Double)] {
+        await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/top")
+            process.arguments = [
+                "-l", "2", "-s", "0", "-stats", "pid,power", "-o", "power",
+                "-n", "15",
+            ]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = Pipe()
+
+            do {
+                try process.run()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+
+                guard let output = String(data: data, encoding: .utf8) else {
+                    return []
+                }
+                return Self.parseTopOutput(output)
+            } catch {
+                return []
+            }
+        }.value
+    }
+
+    nonisolated static func parseTopOutput(_ output: String) -> [(pid_t, Double)] {
+        let components = output.components(separatedBy: "PID")
+        guard let lastSection = components.last else { return [] }
+
+        var results: [(pid_t, Double)] = []
+        let lines = lastSection.components(separatedBy: .newlines)
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("POWER") { continue }
+            let tokens = trimmed.components(separatedBy: .whitespaces).filter {
+                !$0.isEmpty
+            }
+            guard tokens.count >= 2,
+                let pid = pid_t(tokens[0]),
+                let power = Double(tokens[1])
+            else {
+                continue
+            }
+            results.append((pid, power))
+        }
+        return results
+    }
+
+    private func filterAndBuildApps(from pidPowers: [(pid_t, Double)])
+        -> [SignificantEnergyApp]
+    {
+        var results: [SignificantEnergyApp] = []
+        var seenBundleIDs: Set<String> = []
+
+        for (pid, power) in pidPowers {
+            guard power >= threshold else { continue }
+            guard let app = NSRunningApplication(processIdentifier: pid) else {
+                continue
+            }
+
+            // Filter out system background daemons and helper services
+            guard app.activationPolicy == .regular || app.activationPolicy == .accessory else {
+                continue
+            }
+
+            // Skip our own app
+            if let bundleID = app.bundleIdentifier,
+                bundleID == Bundle.main.bundleIdentifier
+            {
+                continue
+            }
+
+            guard let name = app.localizedName, !name.isEmpty else { continue }
+
+            if let bundleID = app.bundleIdentifier {
+                if seenBundleIDs.contains(bundleID) {
+                    continue
+                }
+                seenBundleIDs.insert(bundleID)
+            }
+
+            let energyApp = SignificantEnergyApp(
+                id: pid,
+                pid: pid,
+                name: name,
+                bundleIdentifier: app.bundleIdentifier,
+                powerScore: power,
+                icon: app.icon
+            )
+            results.append(energyApp)
+        }
+
+        return results.sorted { $0.powerScore > $1.powerScore }
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            openMenuTask?.cancel()
+        }
+    }
+}

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -8,7 +8,12 @@ import Observation
 class MenuViewModel {
     private let batteryService: BatteryService
     private let chargeManager: ChargeManager
+    let significantEnergyService: SignificantEnergyService
     private let bootTimestamp: Date?
+
+    var significantApps: [SignificantEnergyApp] {
+        significantEnergyService.apps
+    }
 
     var batteryPercentageText: String = "0%"
     var powerSourceText: String = "Battery"
@@ -60,9 +65,14 @@ class MenuViewModel {
     private var isChargingHoldUntil: Date = .distantPast
     private var stableIsCharging: Bool = false
 
-    init(batteryService: BatteryService, chargeManager: ChargeManager) {
+    init(
+        batteryService: BatteryService,
+        chargeManager: ChargeManager,
+        significantEnergyService: SignificantEnergyService
+    ) {
         self.batteryService = batteryService
         self.chargeManager = chargeManager
+        self.significantEnergyService = significantEnergyService
         self.bootTimestamp = SystemService.bootTimestamp()
         startObservingMetrics()
         startObservingSettings()
@@ -426,11 +436,13 @@ class MenuViewModel {
         updateUptimeText()
         startUptimeTimer()
         batteryService.enableFastPolling()
+        significantEnergyService.startOpenMenuPolling()
     }
 
     func menuDidClose() {
         stopUptimeTimer()
         batteryService.disableFastPolling()
+        significantEnergyService.stopOpenMenuPolling()
     }
 
     func quit() {

--- a/Stasis/Views/MenuBuilder.swift
+++ b/Stasis/Views/MenuBuilder.swift
@@ -56,6 +56,7 @@ class MenuBuilder {
             buildPowerMetricsSection(),
             buildVisualizationSection(),
             buildHardwareSection(),
+            buildEnergyImpactSection(),
         ]
 
         for section in sections where !section.isEmpty {
@@ -219,6 +220,20 @@ class MenuBuilder {
         return items
     }
 
+    private func buildEnergyImpactSection() -> [NSMenuItem] {
+        var items: [NSMenuItem] = []
+
+        if Defaults[.showSignificantEnergyApps] {
+            items.append(
+                createDynamicMenuItem(
+                    view: SignificantEnergyMenuView(service: viewModel.significantEnergyService)
+                )
+            )
+        }
+
+        return items
+    }
+
     private func createInfoItem(
         label: String,
         keyPath: KeyPath<MenuViewModel, String>
@@ -246,6 +261,23 @@ class MenuBuilder {
 
         let menuItem = NSMenuItem()
         menuItem.view = hostingView
+
+        return menuItem
+    }
+
+    private func createDynamicMenuItem<V: View>(view: V) -> NSMenuItem {
+        let hostingView = DynamicallyResizingHostingView(rootView: view)
+        let height = hostingView.fittingSize.height
+        hostingView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: Self.menuWidth,
+            height: height
+        )
+
+        let menuItem = NSMenuItem()
+        menuItem.view = hostingView
+        hostingView.menuItem = menuItem
 
         return menuItem
     }

--- a/Stasis/Views/Settings/DashboardSettingsView.swift
+++ b/Stasis/Views/Settings/DashboardSettingsView.swift
@@ -14,6 +14,7 @@ struct DashboardSettingsView: View {
     @Default(.showPowerDistribution) var showPowerDistribution
     @Default(.showOutputPortsText) var showOutputPortsText
     @Default(.outputVisualizationMode) var outputVisualizationMode
+    @Default(.showSignificantEnergyApps) var showSignificantEnergyApps
 
     var body: some View {
         Form {
@@ -42,6 +43,10 @@ struct DashboardSettingsView: View {
             Section("Power") {
                 Toggle("Battery Power Metrics", isOn: $showInternalPower)
                 Toggle("Adapter Power Metrics", isOn: $showExternalPower)
+            }
+
+            Section("Energy Impact") {
+                Toggle("Apps using significant energy", isOn: $showSignificantEnergyApps)
             }
 
             Section("Visuals") {

--- a/Stasis/Views/Settings/SidebarFooterButtonsView.swift
+++ b/Stasis/Views/Settings/SidebarFooterButtonsView.swift
@@ -82,7 +82,7 @@ struct SidebarBottomButtonsView: View {
                 .contentShape(Circle())
             }
             .buttonStyle(.plain)
-            .help("Reset all preferences...")
+            .help("Reset all preferences")
 
             Spacer()
         }

--- a/Stasis/Views/SignificantEnergyViews.swift
+++ b/Stasis/Views/SignificantEnergyViews.swift
@@ -1,0 +1,164 @@
+import AppKit
+import SwiftUI
+
+class DynamicallyResizingHostingView<V: View>: NSHostingView<V> {
+    weak var menuItem: NSMenuItem?
+    private let menuWidth: CGFloat = 300
+    private var lastReportedHeight: CGFloat = -1
+
+    override var fittingSize: NSSize {
+        let size = super.fittingSize
+        return NSSize(width: menuWidth, height: size.height)
+    }
+
+    override func layout() {
+        super.layout()
+        let currentHeight = self.fittingSize.height
+        if abs(lastReportedHeight - currentHeight) > 0.5 {
+            lastReportedHeight = currentHeight
+            self.frame = NSRect(
+                x: 0,
+                y: 0,
+                width: menuWidth,
+                height: currentHeight
+            )
+            self.invalidateIntrinsicContentSize()
+            if let menuItem = menuItem, let menu = menuItem.menu {
+                menu.update()
+            }
+        }
+    }
+}
+
+struct SignificantEnergyMenuView: View {
+    let service: SignificantEnergyService
+    @State private var isExpanded: Bool = false
+
+    private var apps: [SignificantEnergyApp] {
+        service.apps
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerView
+            if isExpanded {
+                VStack(spacing: 0) {
+                    Divider()
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 4)
+                    expandedContentView
+                }
+            }
+        }
+        .frame(width: 300, alignment: .top)
+    }
+
+    private var headerView: some View {
+        HStack {
+            Text("Significant Energy Apps")
+                .foregroundColor(.secondary)
+                .font(.callout)
+            Spacer(minLength: 16)
+            Image(systemName: "chevron.right")
+                .font(.caption.bold())
+                .foregroundColor(.secondary)
+                .rotationEffect(.degrees(isExpanded ? 90 : 0))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            isExpanded.toggle()
+        }
+    }
+
+    @ViewBuilder
+    private var expandedContentView: some View {
+        if apps.isEmpty {
+            emptyStateView
+        } else {
+            appsListView
+        }
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(Color.green.opacity(0.15))
+                    .frame(width: 40, height: 40)
+                Image(systemName: "leaf.fill")
+                    .font(.system(size: 18))
+                    .foregroundColor(.green)
+            }
+            Text("No Apps Using Significant Energy")
+                .font(.callout.weight(.medium))
+                .foregroundColor(.primary)
+            Text("All applications are running efficiently")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 140)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 14)
+    }
+
+    private var appsListView: some View {
+        ScrollView(.vertical, showsIndicators: apps.count > 5) {
+            VStack(spacing: 0) {
+                ForEach(apps) { app in
+                    SignificantEnergyAppRowView(app: app)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .top)
+        }
+        .frame(height: 140, alignment: .top)
+        .padding(.bottom, 4)
+    }
+}
+
+struct SignificantEnergyAppRowView: View {
+    let app: SignificantEnergyApp
+
+    var body: some View {
+        Button {
+            app.activate()
+        } label: {
+            HStack(spacing: 10) {
+                if let icon = app.icon {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .frame(width: 18, height: 18)
+                } else {
+                    Image(systemName: "app.fill")
+                        .resizable()
+                        .frame(width: 18, height: 18)
+                        .foregroundColor(.secondary)
+                }
+                Text(app.name)
+                    .foregroundColor(.primary)
+                    .font(.callout)
+                    .lineLimit(1)
+                Spacer(minLength: 16)
+                Text(String(format: "%.1f", app.powerScore))
+                    .font(.callout.monospacedDigit().weight(.medium))
+                    .foregroundColor(scoreColor(for: app.powerScore))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func scoreColor(for score: Double) -> Color {
+        if score >= 30.0 {
+            return .red
+        } else if score >= 10.0 {
+            return .orange
+        } else {
+            return .blue
+        }
+    }
+}

--- a/Stasis/Views/SignificantEnergyViews.swift
+++ b/Stasis/Views/SignificantEnergyViews.swift
@@ -4,26 +4,23 @@ import SwiftUI
 class DynamicallyResizingHostingView<V: View>: NSHostingView<V> {
     weak var menuItem: NSMenuItem?
     private let menuWidth: CGFloat = 300
-    private var lastReportedHeight: CGFloat = -1
 
     override var fittingSize: NSSize {
         let size = super.fittingSize
         return NSSize(width: menuWidth, height: size.height)
     }
 
+    override var intrinsicContentSize: NSSize {
+        let size = super.intrinsicContentSize
+        return NSSize(width: menuWidth, height: size.height)
+    }
+
     override func layout() {
         super.layout()
-        let currentHeight = self.fittingSize.height
-        if abs(lastReportedHeight - currentHeight) > 0.5 {
-            lastReportedHeight = currentHeight
-            self.frame = NSRect(
-                x: 0,
-                y: 0,
-                width: menuWidth,
-                height: currentHeight
-            )
-            self.invalidateIntrinsicContentSize()
-            if let menuItem = menuItem, let menu = menuItem.menu {
+        if let menuItem = self.menuItem, let menu = menuItem.menu {
+            let currentHeight = self.fittingSize.height
+            if abs(self.frame.height - currentHeight) > 0.5 {
+                self.frame.size.height = currentHeight
                 menu.update()
             }
         }
@@ -36,6 +33,15 @@ struct SignificantEnergyMenuView: View {
 
     private var apps: [SignificantEnergyApp] {
         service.apps
+    }
+
+    private var currentContentHeight: CGFloat {
+        if apps.isEmpty {
+            return 105.0
+        } else {
+            let rows = min(apps.count, 5)
+            return CGFloat(rows) * 28.0
+        }
     }
 
     var body: some View {
@@ -74,34 +80,39 @@ struct SignificantEnergyMenuView: View {
 
     @ViewBuilder
     private var expandedContentView: some View {
-        if apps.isEmpty {
-            emptyStateView
-        } else {
-            appsListView
+        Group {
+            if apps.isEmpty {
+                emptyStateView
+            } else {
+                appsListView
+            }
         }
+        .frame(height: currentContentHeight, alignment: .top)
+        .clipped()
     }
 
     private var emptyStateView: some View {
         VStack(spacing: 8) {
             ZStack {
                 Circle()
-                    .fill(Color.green.opacity(0.15))
-                    .frame(width: 40, height: 40)
+                    .fill(Color.green.opacity(0.12))
+                    .frame(width: 32, height: 32)
                 Image(systemName: "leaf.fill")
-                    .font(.system(size: 18))
+                    .font(.system(size: 15, weight: .medium))
                     .foregroundColor(.green)
             }
-            Text("No Apps Using Significant Energy")
-                .font(.callout.weight(.medium))
-                .foregroundColor(.primary)
-            Text("All applications are running efficiently")
-                .font(.caption)
-                .foregroundColor(.secondary)
+            VStack(spacing: 2) {
+                Text("No Significant Energy Apps")
+                    .font(.callout.weight(.medium))
+                    .foregroundColor(.primary)
+                Text("All applications are running efficiently")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 140)
-        .padding(.vertical, 4)
-        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     private var appsListView: some View {
@@ -113,7 +124,7 @@ struct SignificantEnergyMenuView: View {
             }
             .frame(maxWidth: .infinity, alignment: .top)
         }
-        .frame(height: 140, alignment: .top)
+        .frame(maxHeight: .infinity, alignment: .top)
         .padding(.bottom, 4)
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature that detects and displays applications using significant energy in the menu bar app. It adds a background service for monitoring high-energy apps, integrates a new SwiftUI menu section to show them, and provides a user preference to enable or disable this feature. The main changes are grouped below.

**Significant Energy Apps detection and service:**

* Added the `SignificantEnergyService` class, which periodically polls system metrics to identify running apps with high energy usage, filters out system/background processes, and exposes the list for UI consumption.
* Introduced the `SignificantEnergyApp` model to represent detected apps, including fields for process ID, name, bundle identifier, power score, and app icon, with an activation method to bring the app to the foreground.

**Menu integration and UI:**

* Added a new expandable "Significant Energy Apps" section to the menu, using `SignificantEnergyMenuView` and a custom dynamic hosting view for proper sizing. The section lists high-energy apps, allows activating them, and shows an empty state when none are detected. [[1]](diffhunk://#diff-d7cf6f8ec579fce24d6804abb61ba56bf501a2fb979ab3c32a4c5806d5f24d6aR1-R175) [[2]](diffhunk://#diff-6aab32447484fb5b519d42e63354ef75aa264f1f109e3ba6fcac94269eb9eeaaR59) [[3]](diffhunk://#diff-6aab32447484fb5b519d42e63354ef75aa264f1f109e3ba6fcac94269eb9eeaaR223-R236) [[4]](diffhunk://#diff-6aab32447484fb5b519d42e63354ef75aa264f1f109e3ba6fcac94269eb9eeaaR268-R284)
* Connected the service and view model to the app's lifecycle, starting and stopping polling as the menu opens and closes, and ensuring the menu updates when the list of significant energy apps changes. [[1]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R13-R20) [[2]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R84-R88) [[3]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffR11-R17) [[4]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffL63-R75) [[5]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffR450-R456) [[6]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R154-R169)

**User settings:**

* Added a new user preference (`showSignificantEnergyApps`) to enable or disable the feature, exposed as a toggle in the dashboard settings. [[1]](diffhunk://#diff-5bdabe8585f494bc0facbc8743e0bcb5ac4b82aaefc27286f343773adb3aceb5R273-R276) [[2]](diffhunk://#diff-47281e395c6a98231d60199442a4cd9b1bc4ceff316e86dcd62f8032a97bfe09R18) [[3]](diffhunk://#diff-47281e395c6a98231d60199442a4cd9b1bc4ceff316e86dcd62f8032a97bfe09R49-R52) [[4]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6L126-R130)

**Minor improvements:**

* Updated help text for the "Reset all preferences" button for clarity.

These changes collectively add a new, user-configurable energy impact section to the menu bar app, helping users identify and manage apps with high energy usage.