### PR TITLE
fix: complete localization coverage and clarify fork provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stasis
 
+> ***This project is a fork of [srimanachanta/Stasis](https://github.com/srimanachanta/Stasis).***
+
 **A smarter battery icon for your MacBook.** Monitor power metrics, manage charge limits, automate power profiles, and extend your battery's lifespan — all from the menu bar.
 
 Stasis gives you real-time insight into your MacBook's power system and lets you control charging behavior directly, without relying on macOS's opaque "Optimized Battery Charging."

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -24893,7 +24893,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "打开菜单栏对框"
+            "value": "打开菜单栏对话框"
           }
         },
         "zh-Hant": {
@@ -43115,6 +43115,204 @@
           "stringUnit": {
             "state": "translated",
             "value": "繁體中文"
+          }
+        }
+      }
+    },
+    "Open the main Stasis dashboard and settings window.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Stasis 主仪表板和设置窗口。"
+          }
+        }
+      }
+    },
+    "Enable or disable force discharging the battery while plugged into AC power.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接交流电源时启用或停用电池强制放电。"
+          }
+        }
+      }
+    },
+    "Start a full battery calibration cycle in Stasis.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Stasis 中开始完整的电池校准周期。"
+          }
+        }
+      }
+    },
+    "Cancel an ongoing battery calibration cycle.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消正在进行的电池校准周期。"
+          }
+        }
+      }
+    },
+    "Enable or disable Heat Protection Mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用或停用散热保护模式。"
+          }
+        }
+      }
+    },
+    "Set Heat Protection Threshold": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置散热保护阈值"
+          }
+        }
+      }
+    },
+    "Set the temperature threshold for Heat Protection Mode (30°C to 50°C).": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置散热保护模式的温度阈值（30°C 至 50°C）。"
+          }
+        }
+      }
+    },
+    "Enable or disable custom MagSafe LED color indication.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用或停用自定义 MagSafe LED 颜色指示。"
+          }
+        }
+      }
+    },
+    "Stasis supports custom URL schemes (**stasis://**) and command-line automation. This is a 100 percent reliable, universal automation system that works in Apple Shortcuts, Raycast, Alfred, and Terminal scripts—without needing an Apple Developer Account.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis 支持自定义 URL 方案（**stasis://**）和命令行自动化。这是一套百分之百可靠、通用的自动化系统，可用于 Apple 快捷指令、Raycast、Alfred 和终端脚本，无需 Apple 开发者账户。"
+          }
+        }
+      }
+    },
+    "How to use in Apple's Shortcuts App": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如何在 Apple 的“快捷指令”App 中使用"
+          }
+        }
+      }
+    },
+    "CLI & Terminal Usage": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 与终端用法"
+          }
+        }
+      }
+    },
+    "You can run any Stasis command from Terminal, shell scripts, Raycast, or Alfred using the `open` command:": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你可以在终端、Shell 脚本、Raycast 或 Alfred 中使用 `open` 命令运行任意 Stasis 命令："
+          }
+        }
+      }
+    },
+    "URL Scheme Reference": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 方案参考"
+          }
+        }
+      }
+    },
+    "Open Apple's **Shortcuts** app on your Mac.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 上打开 Apple 的**快捷指令** App。"
+          }
+        }
+      }
+    },
+    "Create a new Shortcut and add the **Open URL** action.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建一个快捷指令，并添加**打开 URL**操作。"
+          }
+        }
+      }
+    },
+    "Paste any Stasis URL from the reference list below (e.g., `stasis://charge-limit?value=80`).": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴下方参考列表中的任意 Stasis URL（例如 `stasis://charge-limit?value=80`）。"
+          }
+        }
+      }
+    },
+    "Run your Shortcut from your Menu Bar, Keyboard Shortcut, Dock, or Siri!": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可从菜单栏、键盘快捷键、Dock 或 Siri 运行你的快捷指令！"
+          }
+        }
+      }
+    },
+    "Copied": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已复制"
           }
         }
       }

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1638,31 +1638,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Адаптер"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Adapter"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Adaptör"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Adapter"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Adaptér"
           }
         },
         "vi": {
@@ -1686,7 +1686,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Adattatore"
           }
         },
         "pt-PT": {
@@ -1744,31 +1744,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Показатели мощности адаптера"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Adaptervermogensstatistieken"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Adaptör Güç Ölçümleri"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Meritve moči adapterja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Metriky napájania adaptéra"
           }
         },
         "vi": {
@@ -1792,7 +1792,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Metriche di potenza dell'adattatore"
           }
         },
         "pt-PT": {
@@ -1850,31 +1850,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Управление адаптером не поддерживается на этом устройстве."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Adapterbediening wordt niet ondersteund op dit apparaat."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Adaptör kontrolü bu cihazda desteklenmiyor."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Nadzor adapterja ni podprt v tej napravi."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Toto zariadenie nepodporuje ovládanie adaptéra."
           }
         },
         "vi": {
@@ -1898,7 +1898,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Il controllo dell'adattatore non è supportato su questo dispositivo."
           }
         },
         "pt-PT": {
@@ -2062,31 +2062,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Все дисплеи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Alle beeldschermen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Tüm Ekranlar"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Vsi zasloni"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Všetky displeje"
           }
         },
         "vi": {
@@ -2110,7 +2110,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Tutti i display"
           }
         },
         "pt-PT": {
@@ -2371,7 +2371,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Tutte le preferenze sono state ripristinate con successo ai valori predefiniti. L'app verrà ora riavviata."
           }
         },
         "ja": {
@@ -2389,7 +2389,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Alle voorkeuren zijn met succes hersteld naar hun standaardwaarden. De app zal nu opnieuw opstarten."
           }
         },
         "pt-BR": {
@@ -2407,25 +2407,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Все настройки были успешно восстановлены до значений по умолчанию. Приложение будет перезапущено."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Všetky predvoľby boli úspešne obnovené na predvolené hodnoty. Aplikácia sa teraz reštartuje."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Vse nastavitve so bile uspešno ponastavljene na privzete vrednosti. Aplikacija se bo zdaj znova zagnala."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Tüm tercihler başarıyla varsayılan değerlerine geri yüklendi. Uygulama şimdi yeniden başlatılacak."
           }
         },
         "vi": {
@@ -2808,31 +2808,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Подтвердите Stasis в Системных настройках → Элементы входа, чтобы продолжить."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Keur Stasis goed in Systeeminstellingen → Inlogitems om door te gaan."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Devam etmek için Sistem Ayarları → Giriş Öğeleri bölümünde Stasis'i onaylayın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Odobrite Stasis v sistemskih nastavitvah → Elementi za prijavo za nadaljevanje."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Ak chcete pokračovať, schváľte Stasis v Nastaveniach systému → Položky prihlásenia."
           }
         },
         "vi": {
@@ -2856,7 +2856,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Approva Stasis in Impostazioni di sistema → Elementi di accesso per continuare."
           }
         },
         "pt-PT": {
@@ -3021,31 +3021,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Автоматическая загрузка"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Automatisch downloaden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Otomatik indirme"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Samodejni prenos"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Automatické sťahovanie"
           }
         },
         "vi": {
@@ -3069,7 +3069,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Download automatico"
           }
         },
         "pt-PT": {
@@ -3127,31 +3127,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Автоматическая разрядка"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Automatische ontlading"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Otomatik deşarj"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Samodejno praznjenje"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Automatické vybíjanie"
           }
         },
         "vi": {
@@ -3175,7 +3175,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Scarica automatica"
           }
         },
         "pt-PT": {
@@ -3233,31 +3233,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Автоматически проверять наличие обновлений"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Automatisch controleren op updates"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Güncellemeleri otomatik olarak kontrol et"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Samodejno preveri posodobitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Automaticky kontrolovať aktualizácie"
           }
         },
         "vi": {
@@ -3281,7 +3281,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Controlla automaticamente gli aggiornamenti"
           }
         },
         "pt-PT": {
@@ -3339,31 +3339,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Автоматически возобновляйте зарядку, когда уровень заряда батареи падает ниже порогового значения относительно вашего предела заряда."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Hervat het opladen automatisch wanneer de batterij onder de drempel daalt ten opzichte van uw oplaadlimiet."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Pil, şarj sınırınıza göre eşiğin altına düştüğünde şarjı otomatik olarak sürdürün."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Samodejno nadaljujte s polnjenjem, ko baterija pade pod prag glede na vašo omejitev napolnjenosti."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Automaticky obnovte nabíjanie, keď batéria klesne pod prahovú hodnotu vzhľadom na váš limit nabitia."
           }
         },
         "vi": {
@@ -3387,7 +3387,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Riprendi automaticamente la ricarica quando la batteria scende al di sotto della soglia relativa al limite di carica."
           }
         },
         "pt-PT": {
@@ -3552,31 +3552,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Фоновый помощник отключён"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Achtergrondhelper niet verbonden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Arka Plan Yardımcısının Bağlantısı Kesildi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Pomočnik v ozadju ni povezan"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Pomocník na pozadí odpojený"
           }
         },
         "vi": {
@@ -3600,7 +3600,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Helper in background disconnesso"
           }
         },
         "pt-PT": {
@@ -3870,31 +3870,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Аккумулятор и адаптер питания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Batterij en voedingsadapter"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Pil ve Güç Adaptörü"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Baterija in napajalnik"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Batéria a napájací adaptér"
           }
         },
         "vi": {
@@ -3918,7 +3918,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Batteria e adattatore di alimentazione"
           }
         },
         "pt-PT": {
@@ -3976,31 +3976,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Аккумулятор и адаптер питания (%@ W)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Batterij en voedingsadapter (%@ W)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Pil ve Güç Adaptörü (%@ W)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Baterija in napajalnik (%@ W)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Batéria a napájací adaptér (%@ W)"
           }
         },
         "vi": {
@@ -4024,7 +4024,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Batteria e adattatore di alimentazione (%@ W)"
           }
         },
         "pt-PT": {
@@ -4082,31 +4082,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Аккумулятор и адаптер питания (%d W)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Batterij en voedingsadapter (%d W)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Pil ve Güç Adaptörü (%d W)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Baterija in napajalnik (%d W)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Batéria a napájací adaptér (%d W)"
           }
         },
         "vi": {
@@ -4130,7 +4130,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Batteria e adattatore di alimentazione (%d W)"
           }
         },
         "pt-PT": {
@@ -4188,31 +4188,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Аккумулятор и адаптер питания (%lld W)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Batterij en voedingsadapter (%lld W)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Pil ve Güç Adaptörü (%lld W)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Baterija in napajalnik (%lld W)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Batéria a napájací adaptér (%lld W)"
           }
         },
         "vi": {
@@ -4236,7 +4236,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Batteria e adattatore di alimentazione (%lld W)"
           }
         },
         "pt-PT": {
@@ -4294,31 +4294,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Калибровка батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Kalibratie van de batterij"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Pil Kalibrasyonu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Kalibracija baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Kalibrácia batérie"
           }
         },
         "vi": {
@@ -4342,7 +4342,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Calibrazione della batteria"
           }
         },
         "pt-PT": {
@@ -4400,31 +4400,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Требуется калибровка батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Batterijkalibratie nodig"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Pil Kalibrasyonu Zamanı Geldi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Čas za kalibracijo baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Je potrebná kalibrácia batérie"
           }
         },
         "vi": {
@@ -4448,7 +4448,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Calibrazione della batteria dovuta"
           }
         },
         "pt-PT": {
@@ -4612,31 +4612,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Режим работы от батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Batterijmodus"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Pil Modu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Baterijski način"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Režim batérie"
           }
         },
         "vi": {
@@ -4660,7 +4660,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Modalità batteria"
           }
         },
         "pt-PT": {
@@ -4718,31 +4718,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Только батарея"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Alleen batterij"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Yalnızca Pil"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Samo baterija"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Iba batéria"
           }
         },
         "vi": {
@@ -4766,7 +4766,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Solo batteria"
           }
         },
         "pt-PT": {
@@ -4824,31 +4824,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Показатели мощности аккумулятора"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Batterijvermogenstatistieken"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Pil Gücü Ölçümleri"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Meritve moči baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Metriky výkonu batérie"
           }
         },
         "vi": {
@@ -4872,7 +4872,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Metriche di potenza della batteria"
           }
         },
         "pt-PT": {
@@ -4930,31 +4930,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Показания батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Batterijmeting"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Pil Değeri"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Odčitek baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Údaj batérie"
           }
         },
         "vi": {
@@ -4978,7 +4978,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Lettura batteria"
           }
         },
         "pt-PT": {
@@ -5036,31 +5036,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Температура батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Batterijtemperatuur"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Pil Sıcaklığı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Temperatura baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Teplota batérie"
           }
         },
         "vi": {
@@ -5084,7 +5084,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Temperatura della batteria"
           }
         },
         "pt-PT": {
@@ -5142,31 +5142,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Контроль аккумулятора и зарядки MacBook."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Batterij- en oplaadcontrole voor MacBook."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "MacBook için pil ve şarj kontrolü."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Nadzor baterije in polnjenja za MacBook."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Ovládanie batérie a nabíjania pre MacBook."
           }
         },
         "vi": {
@@ -5190,7 +5190,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Controllo della batteria e della ricarica per MacBook."
           }
         },
         "pt-PT": {
@@ -5462,31 +5462,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Калибровка батареи не поддерживается на этом устройстве."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Batterijkalibratie wordt niet ondersteund op dit apparaat."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Pil kalibrasyonu bu cihazda desteklenmiyor."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Ta naprava ne podpira kalibracije baterije."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Toto zariadenie nepodporuje kalibráciu batérie."
           }
         },
         "vi": {
@@ -5510,7 +5510,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "La calibrazione della batteria non è supportata su questo dispositivo."
           }
         },
         "pt-PT": {
@@ -5568,31 +5568,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Режим батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Batterijmodus"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Pil modu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Baterijski način"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Režim batérie"
           }
         },
         "vi": {
@@ -5616,7 +5616,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Modalità batteria"
           }
         },
         "pt-PT": {
@@ -5780,31 +5780,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Быстро мигает оранжевым"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Knippert snel oranje"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Turuncu Hızla Yanıp Sönüyor"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Hitro utripa oranžno"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Rýchlo bliká oranžovo"
           }
         },
         "vi": {
@@ -5828,7 +5828,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Arancione lampeggiante velocemente"
           }
         },
         "pt-PT": {
@@ -5886,31 +5886,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Медленно мигает оранжевым"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Knipperend oranje langzaam"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Yavaş Yanıp Sönen Turuncu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Utripa oranžno počasi"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Blikajúca oranžová pomaly"
           }
         },
         "vi": {
@@ -5934,7 +5934,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Arancione lampeggiante lento"
           }
         },
         "pt-PT": {
@@ -5992,31 +5992,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Создано с упором на практическое состояние аккумулятора и рабочие процессы зарядки."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Gebouwd met de nadruk op praktische batterijstatus en oplaadworkflows."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Pratik pil sağlığı ve şarj iş akışlarına odaklanılarak tasarlandı."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Ustvarjen s poudarkom na praktičnem delovanju baterije in polnjenju."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Postavený so zameraním na praktické pracovné postupy pre zdravie batérie a nabíjanie."
           }
         },
         "vi": {
@@ -6040,7 +6040,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Costruito con particolare attenzione alla salute pratica della batteria e ai flussi di lavoro di ricarica."
           }
         },
         "pt-PT": {
@@ -6098,31 +6098,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Расчет..."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Berekenen..."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Hesaplanıyor..."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Izračun ..."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Prebieha výpočet..."
           }
         },
         "vi": {
@@ -6146,7 +6146,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Calcolo..."
           }
         },
         "pt-PT": {
@@ -6312,31 +6312,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Калибровка (зарядка от %@)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Kalibreren (opladen naar %@)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Kalibre ediliyor (%@'ya şarj ediliyor)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Umerjanje (polnjenje na %@)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Kalibrácia (nabíjanie na %@)"
           }
         },
         "vi": {
@@ -6360,7 +6360,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Calibrazione (ricarica a %@)"
           }
         },
         "pt-PT": {
@@ -6418,31 +6418,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Калибровка (зарядка)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Kalibreren (opladen)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Kalibre ediliyor (Şarj ediliyor)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Umerjanje (polnjenje)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Kalibrácia (nabíjanie)"
           }
         },
         "vi": {
@@ -6466,7 +6466,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Calibrazione (ricarica)"
           }
         },
         "pt-PT": {
@@ -6525,31 +6525,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Калибровка (разгрузка в %@)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Kalibreren (ontladen naar %@)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Kalibrasyon (%@'ya Boşaltma)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Umerjanje (praznjenje na %@)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Kalibrácia (vybíjanie na %@)"
           }
         },
         "vi": {
@@ -6573,7 +6573,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Calibrazione (scarica a %@)"
           }
         },
         "pt-PT": {
@@ -6631,31 +6631,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Калибровка (разрядка)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Kalibreren (ontladen)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Kalibrasyon (Boşaltma)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Umerjanje (praznjenje)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Kalibrácia (vybíjanie)"
           }
         },
         "vi": {
@@ -6679,7 +6679,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Calibrazione (scarica)"
           }
         },
         "pt-PT": {
@@ -6737,31 +6737,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Калибровка (приостановлено — подключите)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Kalibreren (gepauzeerd - aansluiten)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Kalibre ediliyor (Duraklatıldı - Tak)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Umerjanje (zaustavljeno - priključite)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Kalibrácia (pozastavená – zapojenie)"
           }
         },
         "vi": {
@@ -6785,7 +6785,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Calibrazione (in pausa - Collegamento)"
           }
         },
         "pt-PT": {
@@ -6844,31 +6844,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Калибровка (остановка на %@)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Kalibreren (rusten op %@)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Kalibre ediliyor (%@'da dinleniyor)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Umerjanje (mirovanje pri %@)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Kalibrácia (odpočíva pri %@)"
           }
         },
         "vi": {
@@ -6892,7 +6892,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Calibrazione (riposo su %@)"
           }
         },
         "pt-PT": {
@@ -6950,31 +6950,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Калибровка (отдых)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Kalibreren (rusten)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Kalibrasyon (Dinlenme)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Umerjanje (počitek)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Kalibrácia (odpočinok)"
           }
         },
         "vi": {
@@ -6998,7 +6998,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Calibrazione (riposo)"
           }
         },
         "pt-PT": {
@@ -7483,31 +7483,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Отменить калибровку"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Kalibratie annuleren"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Kalibrasyonu İptal Et"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Prekliči kalibracijo"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Zrušiť kalibráciu"
           }
         },
         "vi": {
@@ -7531,7 +7531,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Annulla la calibrazione"
           }
         },
         "pt-PT": {
@@ -7910,31 +7910,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Изменить язык отображения..."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Weergavetaal wijzigen..."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Görüntüleme dilini değiştir..."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Spremeni jezik prikaza ..."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Zmeniť jazyk zobrazenia..."
           }
         },
         "vi": {
@@ -7958,7 +7958,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Cambia lingua di visualizzazione..."
           }
         },
         "pt-PT": {
@@ -8123,31 +8123,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Переопределение лимита заряда"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Laadlimiet negeren"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Şarj Sınırını Geçersiz Kılma"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Preglasitev omejitve polnjenja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Prepísanie limitu nabíjania"
           }
         },
         "vi": {
@@ -8171,7 +8171,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Override del limite di ricarica"
           }
         },
         "pt-PT": {
@@ -8229,31 +8229,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Управление зарядкой"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Laadbeheer"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Şarj Yönetimi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Upravljanje polnjenja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Správa nabíjania"
           }
         },
         "vi": {
@@ -8277,7 +8277,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Gestione della ricarica"
           }
         },
         "pt-PT": {
@@ -8869,31 +8869,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Управление зарядкой не поддерживается на этом устройстве."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Oplaadbeheer wordt niet ondersteund op dit apparaat."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Şarj yönetimi bu cihazda desteklenmiyor."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Upravljanje polnjenja ni podprto v tej napravi."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Správa nabíjania nie je na tomto zariadení podporovaná."
           }
         },
         "vi": {
@@ -8917,7 +8917,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "La gestione della carica non è supportata su questo dispositivo."
           }
         },
         "pt-PT": {
@@ -9188,31 +9188,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Управление зарядкой не поддерживается на этом устройстве."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Oplaadcontrole wordt niet ondersteund op dit apparaat."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Bu cihazda şarj kontrolü desteklenmiyor."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Nadzor polnjenja ni podprt v tej napravi."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Toto zariadenie nepodporuje ovládanie nabíjania."
           }
         },
         "vi": {
@@ -9236,7 +9236,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Il controllo della ricarica non è supportato su questo dispositivo."
           }
         },
         "pt-PT": {
@@ -9294,31 +9294,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "Зарядка возобновляется через"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "Het opladen wordt hervat om"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "Şarj işlemi şu saatte devam eder:"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "Polnjenje se nadaljuje ob"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "Nabíjanie sa obnoví o"
           }
         },
         "vi": {
@@ -9342,7 +9342,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "La ricarica riprende alle"
           }
         },
         "pt-PT": {
@@ -9400,31 +9400,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Статус зарядки изменен"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Laadstatus gewijzigd"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Şarj durumu değişti"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Stanje polnjenja je spremenjeno"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Stav nabíjania sa zmenil"
           }
         },
         "vi": {
@@ -9448,7 +9448,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Lo stato di ricarica è cambiato"
           }
         },
         "pt-PT": {
@@ -9507,31 +9507,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "Зарядка на %@ (переопределить)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "Opladen naar %@ (overschrijven)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "%@'ya şarj etme (Geçersiz Kıl)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "Polnjenje na %@ (preglasitev)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "Nabíjanie na %@ (Override)"
           }
         },
         "vi": {
@@ -9555,7 +9555,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "Ricarica su %@ (override)"
           }
         },
         "pt-PT": {
@@ -9614,31 +9614,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "Зарядка %@..."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "Opladen naar %@..."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "%@'ya şarj ediliyor..."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "Polnjenje na %@ ..."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "Nabíjanie na %@..."
           }
         },
         "vi": {
@@ -9662,7 +9662,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "Ricarica su %@..."
           }
         },
         "pt-PT": {
@@ -9709,7 +9709,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Ricarica fino al limite"
           }
         },
         "ja": {
@@ -9727,7 +9727,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Opladen tot limiet"
           }
         },
         "pt-BR": {
@@ -9745,25 +9745,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Зарядка до лимита"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Nabíjanie po limit"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Polnjenje do omejitve"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Sınıra kadar şarj ediliyor"
           }
         },
         "vi": {
@@ -9827,31 +9827,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Проверьте еще раз"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Controleer opnieuw"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Tekrar Kontrol Et"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Preverite še enkrat"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Skontrolujte znova"
           }
         },
         "vi": {
@@ -9875,7 +9875,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Controlla di nuovo"
           }
         },
         "pt-PT": {
@@ -10147,31 +10147,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Проверьте наличие обновлений сейчас"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Controleer nu op updates"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Güncellemeleri şimdi kontrol edin"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Preverite posodobitve zdaj"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Skontrolujte aktualizácie"
           }
         },
         "vi": {
@@ -10195,7 +10195,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Controlla subito gli aggiornamenti"
           }
         },
         "pt-PT": {
@@ -10253,31 +10253,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Проверьте частоту"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Controleer frequentie"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Frekansı kontrol edin"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Preverite pogostost"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Skontrolujte frekvenciu"
           }
         },
         "vi": {
@@ -10301,7 +10301,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Controlla la frequenza"
           }
         },
         "pt-PT": {
@@ -10573,31 +10573,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Сообщество"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Gemeenschap"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Topluluk"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Skupnost"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Spoločenstva"
           }
         },
         "vi": {
@@ -10621,7 +10621,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Comunità"
           }
         },
         "pt-PT": {
@@ -10786,31 +10786,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Контролируйте, когда Stasis отправляет вам уведомления."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Beheer wanneer Stasis u meldingen stuurt."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Stasis'in size ne zaman bildirim göndereceğini kontrol edin."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Nadzirajte, kdaj vam Stasis pošilja obvestila."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Ovládajte, kedy vám Stasis posiela upozornenia."
           }
         },
         "vi": {
@@ -10834,7 +10834,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Controlla quando Stasis ti invia notifiche."
           }
         },
         "pt-PT": {
@@ -11105,31 +11105,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Количество циклов"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Aantal cycli"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Döngü sayısı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Štetje ciklov"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Počet cyklov"
           }
         },
         "vi": {
@@ -11153,7 +11153,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Conteggio dei cicli"
           }
         },
         "pt-PT": {
@@ -11211,31 +11211,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Ошибка демона — настройки не синхронизированы"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Daemon-fout - Instellingen niet gesynchroniseerd"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Daemon Hatası - Ayarlar Senkronize Edilmedi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Daemon Error - nastavitve niso sinhronizirane"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Chyba démona – nastavenia nie sú synchronizované"
           }
         },
         "vi": {
@@ -11259,7 +11259,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Errore demone: impostazioni non sincronizzate"
           }
         },
         "pt-PT": {
@@ -11317,31 +11317,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "Ежедневно"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "Dagelijks"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "Günlük"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "Dnevno"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "Denne"
           }
         },
         "vi": {
@@ -11365,7 +11365,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "Ogni giorno"
           }
         },
         "pt-PT": {
@@ -11954,31 +11954,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Отключить все уведомления"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Schakel alle meldingen uit"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Tüm bildirimleri devre dışı bırak"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Onemogoči vsa obvestila"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Zakázať všetky upozornenia"
           }
         },
         "vi": {
@@ -12002,7 +12002,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Disattiva tutte le notifiche"
           }
         },
         "pt-PT": {
@@ -12274,31 +12274,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Отключить сон до достижения лимита заряда"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Schakel slaap tot oplaadlimiet uit"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Şarj sınırına kadar uykuyu devre dışı bırak"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Onemogoči spanje do omejitve polnjenja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Zakázať spánok až do limitu nabitia"
           }
         },
         "vi": {
@@ -12322,7 +12322,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Disattiva la modalità di sospensione fino al limite di carica"
           }
         },
         "pt-PT": {
@@ -12380,31 +12380,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Разрядка"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Ontladen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Deşarj"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Praznjenje"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Vybíjanie"
           }
         },
         "vi": {
@@ -12428,7 +12428,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Scarica"
           }
         },
         "pt-PT": {
@@ -12593,31 +12593,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Разрядите аккумулятор до предела заряда, если он подключен к сети выше целевого уровня."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Ontlaad de batterij tot uw laadlimiet wanneer de stekker boven het doelniveau ligt."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Pili hedef seviyenin üzerinde taktığınızda şarj sınırınıza kadar boşaltın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Izpraznite baterijo do meje napolnjenosti, ko jo priključite nad ciljno raven."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Keď je batéria zapojená nad cieľovú úroveň, vybite ju na limit nabitia."
           }
         },
         "vi": {
@@ -12641,7 +12641,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Scarica la batteria fino al limite di carica quando è collegata a un livello superiore al livello target."
           }
         },
         "pt-PT": {
@@ -12807,31 +12807,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "Разрядка до %@..."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "Ontladen tot %@..."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "%@ seviyesine deşarj ediliyor..."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "Praznjenje do %@..."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "Vybíjanie do %@..."
           }
         },
         "vi": {
@@ -12855,7 +12855,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "Scarica fino a %@..."
           }
         },
         "pt-PT": {
@@ -12913,31 +12913,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Закрыть"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Sluiten"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Kapat"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Zapri"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Zavrieť"
           }
         },
         "vi": {
@@ -12961,7 +12961,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Chiudi"
           }
         },
         "pt-PT": {
@@ -13019,31 +13019,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Отображение плавающего HUD в стиле Dynamic Island при изменении состояния зарядки."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Geef een zwevende HUD in Dynamic Island-stijl weer wanneer de oplaadstatus verandert."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Şarj durumu değiştiğinde kayan bir Dynamic Island tarzı HUD görüntüleyin."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Prikažite lebdeči HUD v slogu Dynamic Island, ko se stanje polnjenja spremeni."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Zobrazte plávajúci HUD v štýle Dynamic Island, keď sa zmení stav nabíjania."
           }
         },
         "vi": {
@@ -13067,7 +13067,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Visualizza un HUD mobile in stile Dynamic Island quando cambia lo stato di carica."
           }
         },
         "pt-PT": {
@@ -13125,31 +13125,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Отображать процент заряда батареи рядом или внутри значка в строке меню."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Geef het batterijpercentage weer naast of in het menubalkpictogram."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Pil yüzdesini menü çubuğu simgesinin yanında veya içinde görüntüleyin."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Prikažite odstotek baterije poleg ikone menijske vrstice ali znotraj nje."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Zobrazte percento batérie vedľa alebo vo vnútri ikony na lište ponuky."
           }
         },
         "vi": {
@@ -13173,7 +13173,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Visualizza la percentuale della batteria accanto o all'interno dell'icona della barra dei menu."
           }
         },
         "pt-PT": {
@@ -13231,31 +13231,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Режим отображения"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Weergavemodus"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Ekran modu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Način prikaza"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Režim zobrazenia"
           }
         },
         "vi": {
@@ -13279,7 +13279,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Modalità di visualizzazione"
           }
         },
         "pt-PT": {
@@ -13443,31 +13443,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Разрядка до лимита"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Ontladen tot de laadlimiet"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Şarj sınırına kadar deşarj"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Praznjenje do omejitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Vybíjanie po limit"
           }
         },
         "vi": {
@@ -13491,7 +13491,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Scarica fino al limite"
           }
         },
         "pt-PT": {
@@ -13656,31 +13656,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Продолжительность"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Duur"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Süre"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Trajanje"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Trvanie"
           }
         },
         "vi": {
@@ -13704,7 +13704,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Durata"
           }
         },
         "pt-PT": {
@@ -14297,31 +14297,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Включить автоматическую калибровку"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Schakel automatische kalibratie in"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Otomatik kalibrasyonu etkinleştir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Omogoči samodejno kalibracijo"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Povoliť automatickú kalibráciu"
           }
         },
         "vi": {
@@ -14345,7 +14345,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Abilita la calibrazione automatica"
           }
         },
         "pt-PT": {
@@ -14403,31 +14403,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Включить защиту от перегрева"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Schakel hittebescherming in"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Isı korumasını etkinleştir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Omogoči toplotno zaščito"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Aktivujte tepelnú ochranu"
           }
         },
         "vi": {
@@ -14451,7 +14451,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Abilita la protezione dal calore"
           }
         },
         "pt-PT": {
@@ -15365,31 +15365,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Включить режим плавания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Zeilmodus inschakelen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Yelken Modunu Etkinleştir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Omogoči način jadranja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Zapnúť režim plachtenia"
           }
         },
         "vi": {
@@ -15413,7 +15413,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Attiva Modalità Navigazione"
           }
         },
         "pt-PT": {
@@ -15897,31 +15897,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Каждые 14 дней"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Elke 14 dagen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Her 14 günde bir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Vsakih 14 dni"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Každých 14 dní"
           }
         },
         "vi": {
@@ -15945,7 +15945,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Ogni 14 giorni"
           }
         },
         "pt-PT": {
@@ -16003,31 +16003,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Каждые 30 дней"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Elke 30 dagen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Her 30 günde bir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Vsakih 30 dni"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Každých 30 dní"
           }
         },
         "vi": {
@@ -16051,7 +16051,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Ogni 30 giorni"
           }
         },
         "pt-PT": {
@@ -16109,31 +16109,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Каждые 60 дней"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Elke 60 dagen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Her 60 günde bir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Vsakih 60 dni"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Každých 60 dní"
           }
         },
         "vi": {
@@ -16157,7 +16157,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Ogni 60 giorni"
           }
         },
         "pt-PT": {
@@ -16215,31 +16215,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Каждые 7 дней"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Elke 7 dagen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Her 7 günde bir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Vsakih 7 dni"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Každých 7 dní"
           }
         },
         "vi": {
@@ -16263,7 +16263,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Ogni 7 giorni"
           }
         },
         "pt-PT": {
@@ -16417,7 +16417,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Impossibile installare l'assistente per la ricarica"
           }
         },
         "ja": {
@@ -16435,7 +16435,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Kan oplaadhulp niet installeren"
           }
         },
         "pt-BR": {
@@ -16453,25 +16453,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Не удалось установить помощник по зарядке."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Nepodarilo sa nainštalovať pomocníka pri nabíjaní"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Namestitev pomočnika za polnjenje ni uspela"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Şarj yardımcısı yüklenemedi"
           }
         },
         "vi": {
@@ -16524,7 +16524,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Impossibile disinstallare l'assistente per la ricarica"
           }
         },
         "ja": {
@@ -16542,7 +16542,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Kan oplaadhulp niet verwijderen"
           }
         },
         "pt-BR": {
@@ -16560,25 +16560,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Не удалось удалить помощник по зарядке."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Nepodarilo sa odinštalovať pomocníka pri nabíjaní"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Odstranitev pomočnika za polnjenje ni uspela"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Şarj yardımcısı kaldırılamadı"
           }
         },
         "vi": {
@@ -16643,31 +16643,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Для надежного управления зарядом убедитесь, что функция «Оптимизация зарядки аккумулятора» отключена, а встроенный лимит заряда Apple находится точно на значении **%@** в **Настройки системы → Аккумулятор**."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Voor betrouwbaar laadbeheer zorgt u ervoor dat \"Batterijopladen optimaliseren\" is uitgeschakeld en dat de eigen laadlimiet van Apple precies op **%@** ligt in **Systeeminstellingen → Batterij**."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Güvenilir şarj yönetimi için **Sistem Ayarları → Pil**'de \"Pil Şarjını Optimize Et\" seçeneğinin devre dışı olduğundan ve Apple'ın yerel Şarj Limitinin tam olarak **%@** değerinde olduğundan emin olun."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Za zanesljivo upravljanje polnjenja zagotovite, da je »Optimize Battery Charging« onemogočeno in da je Applova izvorna omejitev polnjenja točno na **%@** v **Sistemske nastavitve → Baterija**."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Pre spoľahlivú správu nabíjania sa uistite, že je vypnutá možnosť „Optimalizovať nabíjanie batérie“ a že natívny limit nabíjania spoločnosti Apple je presne na **%@** v **Nastavenia systému → Batéria**."
           }
         },
         "vi": {
@@ -16691,7 +16691,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Per una gestione affidabile della carica, assicurati che \"Ottimizza ricarica batteria\" sia disabilitato e che il limite di carica nativo di Apple sia esattamente su **%@** in **Impostazioni di sistema → Batteria**."
           }
         },
         "pt-PT": {
@@ -16749,31 +16749,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Принудительная разрядка"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Geforceerd ontladen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Zorla Deşarj"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Prisilno praznjenje"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Vynútené vybíjanie"
           }
         },
         "vi": {
@@ -16797,7 +16797,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Scarica forzata"
           }
         },
         "pt-PT": {
@@ -17176,31 +17176,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Принудительная разрядка"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Geforceerd ontladen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Zorla Deşarj Ediliyor"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Prisilno praznjenje"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Vynútené vybíjanie"
           }
         },
         "vi": {
@@ -17224,7 +17224,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Scarica forzata in corso"
           }
         },
         "pt-PT": {
@@ -17495,31 +17495,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Полностью заряжен"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Volledig opgeladen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Tamamen Şarj Edildi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Popolnoma napolnjen"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Plne nabité"
           }
         },
         "vi": {
@@ -17543,7 +17543,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Completamente carico"
           }
         },
         "pt-PT": {
@@ -17707,31 +17707,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Общая информация о состоянии системы и аккумулятора отображается в раскрывающемся меню."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Algemene systeem- en batterijstatusinformatie weergegeven in de vervolgkeuzelijst."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Açılır menüde gösterilen genel sistem ve pil durumu bilgileri."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Splošne informacije o sistemu in stanju baterije, prikazane v spustnem meniju."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Všeobecné informácie o systéme a stave batérie zobrazené v rozbaľovacej ponuke."
           }
         },
         "vi": {
@@ -17755,7 +17755,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Informazioni generali sul sistema e sullo stato della batteria visualizzate nel menu a discesa."
           }
         },
         "pt-PT": {
@@ -18240,31 +18240,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "Зеленый"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "Groen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "Yeşil"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "zelena"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "Zelená"
           }
         },
         "vi": {
@@ -18346,31 +18346,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Состояние батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Batterijconditie"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Pil Sağlığı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Stanje baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Zdravie batérie"
           }
         },
         "vi": {
@@ -18394,7 +18394,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Stato batteria"
           }
         },
         "pt-PT": {
@@ -18452,31 +18452,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Тепловая защита"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Hittebescherming"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Isı Koruması"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Toplotna zaščita"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Tepelná ochrana"
           }
         },
         "vi": {
@@ -18500,7 +18500,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Protezione dal calore"
           }
         },
         "pt-PT": {
@@ -18975,7 +18975,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Demone helper installato con successo."
           }
         },
         "ja": {
@@ -18993,7 +18993,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Helper-daemon succesvol geïnstalleerd."
           }
         },
         "pt-BR": {
@@ -19011,25 +19011,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Вспомогательный демон успешно установлен."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Pomocný démon úspešne nainštalovaný."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Pomožni demon je uspešno nameščen."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Yardımcı arka plan programı başarıyla yüklendi."
           }
         },
         "vi": {
@@ -19082,7 +19082,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Demone helper disinstallato correttamente. L'app verrà ora riavviata."
           }
         },
         "ja": {
@@ -19100,7 +19100,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Helper-daemon succesvol verwijderd. De app zal nu opnieuw opstarten."
           }
         },
         "pt-BR": {
@@ -19118,25 +19118,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Вспомогательный демон успешно удален. Приложение будет перезапущено."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Pomocný démon bol úspešne odinštalovaný. Aplikácia sa teraz reštartuje."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Pomožni demon je uspešno odstranjen. Aplikacija se bo zdaj znova zagnala."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Yardımcı arka plan programı başarıyla kaldırıldı. Uygulama şimdi yeniden başlatılacak."
           }
         },
         "vi": {
@@ -19837,31 +19837,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Установить вспомогательный демон"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Installeer de helper-daemon"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Yardımcı arka plan programını yükleyin"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Namestite demon pomočnika"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Nainštalujte pomocného démona"
           }
         },
         "vi": {
@@ -19885,7 +19885,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Installa il demone helper"
           }
         },
         "pt-PT": {
@@ -20050,31 +20050,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Интервал"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Interval"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Aralık"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Interval"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Interval"
           }
         },
         "vi": {
@@ -20098,7 +20098,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Intervallo"
           }
         },
         "pt-PT": {
@@ -20157,31 +20157,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "Пришло время плановой калибровки батареи. Это разрядит ваш Mac до %@ перед подзарядкой."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "Het is tijd voor uw geplande batterijkalibratie. Hierdoor wordt uw Mac ontladen naar %@ voordat deze opnieuw wordt opgeladen."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "Planlanmış pil kalibrasyonunuzun zamanı geldi. Bu, Mac'inizi yeniden şarj etmeden önce %@'ya boşaltacaktır."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "Čas je za načrtovano kalibracijo baterije. S tem se bo vaš Mac pred ponovnim polnjenjem izpraznil na %@."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "Je čas na naplánovanú kalibráciu batérie. Týmto sa váš Mac pred nabíjaním vybije na %@."
           }
         },
         "vi": {
@@ -20205,7 +20205,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "È il momento della calibrazione programmata della batteria. Ciò scaricherà il tuo Mac su %@ prima di ricaricarlo."
           }
         },
         "pt-PT": {
@@ -20263,31 +20263,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "Светодиод во время термозащиты"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "LED tijdens hittebescherming"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "Isı koruması sırasında LED"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "LED med toplotno zaščito"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "LED počas tepelnej ochrany"
           }
         },
         "vi": {
@@ -20311,7 +20311,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "LED durante la protezione dal calore"
           }
         },
         "pt-PT": {
@@ -20369,31 +20369,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Язык"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Taal"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Dil"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Jezik"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Jazyk"
           }
         },
         "vi": {
@@ -20417,7 +20417,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Lingua"
           }
         },
         "pt-PT": {
@@ -20475,31 +20475,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "Последняя калибровка на %@"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "Laatst gekalibreerd op %@"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "En son %@'da kalibre edildi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "Nazadnje kalibriran na %@"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "Naposledy kalibrované na %@"
           }
         },
         "vi": {
@@ -20523,7 +20523,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "Ultima calibrazione su %@"
           }
         },
         "pt-PT": {
@@ -20581,31 +20581,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Запуск при входе в систему"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Start bij inloggen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Giriş sırasında başlat"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Zaženi ob prijavi"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Spustite pri prihlásení"
           }
         },
         "vi": {
@@ -20629,7 +20629,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Avvia all'accesso"
           }
         },
         "pt-PT": {
@@ -20794,31 +20794,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Достигнут лимит"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Limiet bereikt"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Sınıra Ulaşıldı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Omejitev dosežena"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Limit dosiahnutý"
           }
         },
         "vi": {
@@ -20842,7 +20842,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Limite raggiunto"
           }
         },
         "pt-PT": {
@@ -20900,31 +20900,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Ограничьте максимальный уровень заряда, чтобы продлить срок службы аккумулятора."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Beperk het maximale laadniveau om de levensduur van de batterij te verlengen."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Pil ömrünü uzatmak için maksimum şarj seviyesini sınırlayın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Omejite najvišjo raven napolnjenosti, da podaljšate življenjsko dobo baterije."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Obmedzte maximálnu úroveň nabitia, aby ste predĺžili životnosť batérie."
           }
         },
         "vi": {
@@ -20948,7 +20948,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Limita il livello massimo di carica per prolungare la durata della batteria."
           }
         },
         "pt-PT": {
@@ -21006,31 +21006,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Режим низкого энергопотребления"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Low Power-modus"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Düşük Güç Modu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Način nizke porabe"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Režim nízkej spotreby"
           }
         },
         "vi": {
@@ -21054,7 +21054,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Modalità di risparmio energetico"
           }
         },
         "pt-PT": {
@@ -21112,31 +21112,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Только дисплей Mac"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Alleen Mac-weergave"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Yalnızca Mac Ekranı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Samo zaslon Mac"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Iba displej Mac"
           }
         },
         "vi": {
@@ -21160,7 +21160,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Solo visualizzazione Mac"
           }
         },
         "pt-PT": {
@@ -21218,31 +21218,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "Светодиодное управление MagSafe"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED-bediening"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED Kontrolü"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED Control"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED ovládanie"
           }
         },
         "vi": {
@@ -21266,7 +21266,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "Controllo LED MagSafe"
           }
         },
         "pt-PT": {
@@ -21538,31 +21538,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Управление светодиодами MagSafe не поддерживается на этом устройстве."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "MagSafe LED-bediening wordt niet ondersteund op dit apparaat."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "MagSafe LED kontrolü bu cihazda desteklenmiyor."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Nadzor MagSafe LED ni podprt v tej napravi."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Ovládanie MagSafe LED nie je na tomto zariadení podporované."
           }
         },
         "vi": {
@@ -21586,7 +21586,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Il controllo LED MagSafe non è supportato su questo dispositivo."
           }
         },
         "pt-PT": {
@@ -21858,31 +21858,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "Управление светодиодом MagSafe"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "Beheer MagSafe LED"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "MagSafe LED'i Yönet"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "Upravljajte MagSafe LED"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "Spravujte MagSafe LED"
           }
         },
         "vi": {
@@ -21906,7 +21906,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "Gestisci il LED MagSafe"
           }
         },
         "pt-PT": {
@@ -21964,31 +21964,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Управление зарядкой"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Beheer het opladen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Şarjı yönet"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Upravljanje polnjenja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Spravujte nabíjanie"
           }
         },
         "vi": {
@@ -22012,7 +22012,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Gestisci la ricarica"
           }
         },
         "pt-PT": {
@@ -22284,31 +22284,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Значок строки меню"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Menubalkpictogram"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Menü Çubuğu Simgesi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Ikona menijske vrstice"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Ikona panela s ponukami"
           }
         },
         "vi": {
@@ -22332,7 +22332,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Icona della barra dei menu"
           }
         },
         "pt-PT": {
@@ -22390,31 +22390,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Элементы управления меню"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Menubediening"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Menü Kontrolleri"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Kontrole menija"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Ovládacie prvky ponuky"
           }
         },
         "vi": {
@@ -22438,7 +22438,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Controlli del menu"
           }
         },
         "pt-PT": {
@@ -22496,31 +22496,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "Ежемесячно"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "Maandelijks"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "Aylık"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "Mesečno"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "Mesačne"
           }
         },
         "vi": {
@@ -22544,7 +22544,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "Mensile"
           }
         },
         "pt-PT": {
@@ -23559,31 +23559,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Только уведомлять"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Alleen op de hoogte stellen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Yalnızca bildir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Samo obvestilo"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Iba upozorniť"
           }
         },
         "vi": {
@@ -23607,7 +23607,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Solo notifica"
           }
         },
         "pt-PT": {
@@ -23877,31 +23877,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "Работает от батареи"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "Op batterij"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "Pille Çalışırken"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "Na baterijo"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "Na batériu"
           }
         },
         "vi": {
@@ -23925,7 +23925,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "A batteria"
           }
         },
         "pt-PT": {
@@ -23983,31 +23983,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "В режиме ожидания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "In de wacht"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "Beklemede"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "Na čakanju"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "Podržané"
           }
         },
         "vi": {
@@ -24031,7 +24031,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "In attesa"
           }
         },
         "pt-PT": {
@@ -24945,31 +24945,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Открыть настройки"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Instellingen openen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Ayarları Aç"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Odprite nastavitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Otvorte Nastavenia"
           }
         },
         "vi": {
@@ -24993,7 +24993,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Apri Impostazioni"
           }
         },
         "pt-PT": {
@@ -25479,31 +25479,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Оранжевый"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Oranje"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Turuncu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Oranžna"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Oranžová"
           }
         },
         "vi": {
@@ -25527,7 +25527,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Arancione"
           }
         },
         "pt-PT": {
@@ -25585,31 +25585,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Первоначально создан на базе открытого исходного кода, а затем получил дальнейшее развитие с новыми функциями."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Oorspronkelijk voortgekomen uit een open-sourcebasis, daarna verder ontwikkeld met nieuwe functies."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Başlangıçta açık kaynaklı bir tabandan oluşturuldu, daha sonra yeni özelliklerle daha da geliştirildi."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Prvotno razcepljen iz odprtokodne baze, nato pa se je dodatno razvil z novimi funkcijami."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Pôvodne rozvetvené zo základne s otvoreným zdrojom, potom sa ďalej vyvíjalo s novými funkciami."
           }
         },
         "vi": {
@@ -25633,7 +25633,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Originariamente biforcato da una base open source, poi sviluppato ulteriormente con nuove funzionalità."
           }
         },
         "pt-PT": {
@@ -25691,31 +25691,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Выходные порты"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Uitgangspoorten"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Çıkış Bağlantı Noktaları"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Izhodna vrata"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Výstupné porty"
           }
         },
         "vi": {
@@ -25739,7 +25739,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Porte di uscita"
           }
         },
         "pt-PT": {
@@ -25797,31 +25797,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Текстовая строка выходных портов"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Tekstrij uitvoerpoorten"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Çıkış bağlantı noktaları metin satırı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Besedilna vrstica izhodnih vrat"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Riadok textu výstupných portov"
           }
         },
         "vi": {
@@ -25845,7 +25845,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Riga di testo delle porte di uscita"
           }
         },
         "pt-PT": {
@@ -25903,31 +25903,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Приостановите зарядку, когда температура батареи превысит пороговое значение."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Pauzeer het opladen wanneer de batterijtemperatuur de drempelwaarde overschrijdt."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Pil sıcaklığı eşiği aştığında şarjı duraklatın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Zaustavite polnjenje, ko temperatura baterije preseže prag."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Pozastavte nabíjanie, keď teplota batérie prekročí prahovú hodnotu."
           }
         },
         "vi": {
@@ -25951,7 +25951,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Sospendere la ricarica quando la temperatura della batteria supera la soglia."
           }
         },
         "pt-PT": {
@@ -26116,31 +26116,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Периодически выполняйте цикл полной разрядки и подзарядки для поддержания точных показаний емкости аккумулятора."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Voer periodiek een volledige ontlaad- en oplaadcyclus uit om nauwkeurige metingen van de batterijcapaciteit te behouden."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Pil kapasitesinin doğru okunmasını sağlamak için periyodik olarak tam deşarj ve yeniden şarj döngüsünü çalıştırın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Občasno zaženite cikel polnega praznjenja in ponovnega polnjenja, da ohranite točne odčitke zmogljivosti baterije."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Pravidelne spúšťajte cyklus úplného vybitia a dobitia, aby ste udržali presné údaje o kapacite batérie."
           }
         },
         "vi": {
@@ -26164,7 +26164,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Eseguire periodicamente un ciclo completo di scarica e ricarica per mantenere letture accurate della capacità della batteria."
           }
         },
         "pt-PT": {
@@ -26211,7 +26211,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Apri Impostazioni di sistema -> Generali -> Elementi di accesso e consenti l'esecuzione di Stasis in background, quindi riprova."
           }
         },
         "ja": {
@@ -26229,7 +26229,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Open Systeeminstellingen -> Algemeen -> Inlogitems en laat Stasis op de achtergrond draaien. Probeer het vervolgens opnieuw."
           }
         },
         "pt-BR": {
@@ -26247,25 +26247,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Откройте «Настройки системы» -> «Основные» -> «Элементы входа» и разрешите работу Stasis в фоновом режиме, а затем повторите попытку."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Otvorte Nastavenia systému -> Všeobecné -> Položky prihlásenia a povoľte spustenie Stasis na pozadí, potom to skúste znova."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Odprite Sistemske nastavitve -> Splošno -> Elementi za prijavo in dovolite, da Stasis teče v ozadju, nato pa poskusite znova."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Lütfen Sistem Ayarları -> Genel -> Giriş Öğeleri'ni açın ve Stasis'in arka planda çalışmasına izin verin, ardından tekrar deneyin."
           }
         },
         "vi": {
@@ -26329,31 +26329,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Подключено"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Aangesloten"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Takılı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Priklopljen"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Zapojené"
           }
         },
         "vi": {
@@ -26377,7 +26377,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Collegato"
           }
         },
         "pt-PT": {
@@ -26435,31 +26435,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Подключен (не заряжается)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Aangesloten (niet opladen)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Takılı (Şarj Olmuyor)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Priklopljen (brez polnjenja)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Zapojené (nenabíja sa)"
           }
         },
         "vi": {
@@ -26483,7 +26483,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Collegato (non in carica)"
           }
         },
         "pt-PT": {
@@ -26859,31 +26859,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Мощность"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Macht"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Güç"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Moč"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Sila"
           }
         },
         "vi": {
@@ -26907,7 +26907,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Potenza"
           }
         },
         "pt-PT": {
@@ -26965,31 +26965,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Адаптер питания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Voedingsadapter"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Güç Adaptörü"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Napajalni adapter"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Napájací adaptér"
           }
         },
         "vi": {
@@ -27013,7 +27013,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Adattatore di alimentazione"
           }
         },
         "pt-PT": {
@@ -27071,31 +27071,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Адаптер питания (%@ W)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Voedingsadapter (%@ W)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Güç Adaptörü (%@ W)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Napajalnik (%@ W)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Napájací adaptér (%@ W)"
           }
         },
         "vi": {
@@ -27119,7 +27119,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Adattatore di alimentazione (%@ W)"
           }
         },
         "pt-PT": {
@@ -27177,31 +27177,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Адаптер питания (%d W)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Voedingsadapter (%d W)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Güç Adaptörü (%d W)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Napajalnik (%d W)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Napájací adaptér (%d W)"
           }
         },
         "vi": {
@@ -27225,7 +27225,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Adattatore di alimentazione (%d W)"
           }
         },
         "pt-PT": {
@@ -27283,31 +27283,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Адаптер питания (%lld W)"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Voedingsadapter (%lld W)"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Güç Adaptörü (%lld W)"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Napajalnik (%lld W)"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Napájací adaptér (%lld W)"
           }
         },
         "vi": {
@@ -27331,7 +27331,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Adattatore di alimentazione (%lld W)"
           }
         },
         "pt-PT": {
@@ -27389,31 +27389,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Только питание"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Alleen stroom"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Yalnızca Güç"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Samo napajanje"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Iba napájanie"
           }
         },
         "vi": {
@@ -27437,7 +27437,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Solo alimentazione"
           }
         },
         "pt-PT": {
@@ -27495,31 +27495,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Источник питания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Stroombron"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Güç Kaynağı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Vir napajanja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Zdroj napájania"
           }
         },
         "vi": {
@@ -27543,7 +27543,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Fonte di energia"
           }
         },
         "pt-PT": {
@@ -27601,31 +27601,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Схема распределения мощности"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Stroomverdelingsdiagram"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Güç dağıtım şeması"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Diagram porazdelitve moči"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Schéma distribúcie energie"
           }
         },
         "vi": {
@@ -27649,7 +27649,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Diagramma di distribuzione dell'energia"
           }
         },
         "pt-PT": {
@@ -27707,31 +27707,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Источник питания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Stroombron"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Güç kaynağı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Vir energije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Zdroj energie"
           }
         },
         "vi": {
@@ -27755,7 +27755,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Fonte di energia"
           }
         },
         "pt-PT": {
@@ -27920,31 +27920,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Не позволяйте вашему Mac переходить в спящий режим во время зарядки до достижения предела заряда. Режим сна снова включается при достижении предела или отключении адаптера."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Voorkom dat uw Mac in de sluimerstand gaat terwijl hij de oplaadlimiet nadert. De slaapstand wordt opnieuw ingeschakeld zodra de limiet is bereikt of de adapter is losgekoppeld."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Mac'inizin şarj sınırına doğru şarj olurken uyku moduna geçmesini önleyin. Sınıra ulaşıldığında veya adaptörün bağlantısı kesildiğinde uyku yeniden etkinleştirilir."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Preprečite, da bi vaš Mac spal, medtem ko se polni proti omejitvi napolnjenosti. Spanje je znova omogočeno, ko je dosežena omejitev ali je adapter odklopljen."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Zabráňte tomu, aby váš Mac spal počas nabíjania smerom k limitu nabitia. Po dosiahnutí limitu alebo odpojení adaptéra sa režim spánku znova aktivuje."
           }
         },
         "vi": {
@@ -27968,7 +27968,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Impedisci al tuo Mac di andare in stop mentre si ricarica verso il limite di carica. La modalità di sospensione viene riattivata una volta raggiunto il limite o quando l'adattatore viene disconnesso."
           }
         },
         "pt-PT": {
@@ -28026,31 +28026,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Привилегированный помощник"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Helper met verhoogde bevoegdheden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Ayrıcalıklı Yardımcı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Privilegiran pomočnik"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Privilegovaný pomocník"
           }
         },
         "vi": {
@@ -28074,7 +28074,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Helper privilegiato"
           }
         },
         "pt-PT": {
@@ -28451,31 +28451,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Выйти из Stasis?"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Stoppen met Stasis?"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Stasis'ten çıkılsın mı?"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Zapustiti Stasis?"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Ukončiť Stasis?"
           }
         },
         "vi": {
@@ -28499,7 +28499,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Uscire da Stasis?"
           }
         },
         "pt-PT": {
@@ -28557,31 +28557,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Выход из Stasis остановит работу фоновых вспомогательных служб. Ограничения по зарядке аккумулятора и защита больше не будут работать."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Als u Stasis afsluit, worden de achtergrondhulpdiensten stopgezet. Limieten en beveiligingen voor het opladen van de batterij werken niet meer."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Stasis'ten çıkmak arka planda yardımcı hizmetleri durduracaktır. Pil şarj sınırları ve korumaları artık çalışmayacak."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Če zapustite Stasis, boste ustavili pomočne storitve v ozadju. Omejitve polnjenja baterije in zaščite ne bodo več delovale."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Ukončením Stasis zastavíte pomocné služby na pozadí. Limity a ochrany nabíjania batérie už nebudú fungovať."
           }
         },
         "vi": {
@@ -28605,7 +28605,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "L'uscita da Stasis interromperà i servizi di supporto in background. I limiti e le protezioni per la ricarica della batteria non funzioneranno più."
           }
         },
         "pt-PT": {
@@ -28663,31 +28663,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Сообщить об ошибке"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Rapporteer een bug"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Hata bildir"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Prijavite napako"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Nahlásiť chybu"
           }
         },
         "vi": {
@@ -28711,7 +28711,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Segnala un bug"
           }
         },
         "pt-PT": {
@@ -28769,31 +28769,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Запросить функцию"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Vraag een functie aan"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Bir özellik isteyin"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Zahtevajte funkcijo"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Požiadajte o funkciu"
           }
         },
         "vi": {
@@ -28817,7 +28817,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Richiedi una funzionalità"
           }
         },
         "pt-PT": {
@@ -29408,31 +29408,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Отдыхаем в %@..."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Rusten bij %@..."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "%@'da dinleniyor..."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Počitek na %@..."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Odpočíva pri %@..."
           }
         },
         "vi": {
@@ -29456,7 +29456,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Riposo a %@..."
           }
         },
         "pt-PT": {
@@ -29514,31 +29514,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Режим плавания"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Zeilmodus"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Yelken Modu"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Način jadranja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Režim plachtenia"
           }
         },
         "vi": {
@@ -29562,7 +29562,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Modalità Navigazione"
           }
         },
         "pt-PT": {
@@ -30260,31 +30260,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Выберите язык отображения для Stasis. Для применения изменений требуется перезагрузка."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Selecteer de weergavetaal voor Stasis. Een herstart is vereist om wijzigingen toe te passen."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Stasis için ekran dilini seçin. Değişikliklerin uygulanması için yeniden başlatma gereklidir."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Izberite jezik prikaza za Stasis. Za uveljavitev sprememb je potreben ponovni zagon."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Vyberte jazyk zobrazenia pre Stasis. Na uplatnenie zmien je potrebný reštart."
           }
         },
         "vi": {
@@ -30308,7 +30308,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Seleziona la lingua di visualizzazione per Stasis. Per applicare le modifiche è necessario un riavvio."
           }
         },
         "pt-PT": {
@@ -32610,31 +32610,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Показывать состояние зарядки в Notch HUD"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Toon de laadstatus in Notch HUD"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Notch HUD'da şarj durumunu göster"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Prikaži stanje napolnjenosti v Notch HUD"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Zobrazte stav nabíjania v Notch HUD"
           }
         },
         "vi": {
@@ -32658,7 +32658,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Mostra lo stato di ricarica nell'HUD di Notch"
           }
         },
         "pt-PT": {
@@ -32716,31 +32716,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Показать элементы управления ручной зарядкой"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Handmatige oplaadbedieningen weergeven"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Manuel şarj kontrollerini göster"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Pokaži ročne kontrole polnjenja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Zobraziť ovládacie prvky manuálneho nabíjania"
           }
         },
         "vi": {
@@ -32764,7 +32764,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Mostra i controlli di ricarica manuale"
           }
         },
         "pt-PT": {
@@ -32822,31 +32822,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Показать на экране блокировки"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Toon op vergrendelscherm"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Kilit ekranında göster"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Pokaži na zaklenjenem zaslonu"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Zobraziť na uzamknutej obrazovke"
           }
         },
         "vi": {
@@ -32870,7 +32870,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Mostra nella schermata di blocco"
           }
         },
         "pt-PT": {
@@ -32928,31 +32928,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Показывать выходную мощность"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Uitgaand vermogen tonen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Çıkış gücünü göster"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Prikaži izhodno moč"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Zobraziť výstupný výkon"
           }
         },
         "vi": {
@@ -32976,7 +32976,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Mostra la potenza in uscita"
           }
         },
         "pt-PT": {
@@ -33141,31 +33141,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Запрет перехода в спящий режим"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Sluimerstand voorkomen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Uyku Modunu Engelleme"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Preprečevanje spanja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Zabránenie spánku"
           }
         },
         "vi": {
@@ -33189,7 +33189,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Prevenzione stop"
           }
         },
         "pt-PT": {
@@ -33354,31 +33354,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Звук"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Geluid"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Ses"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Zvok"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Zvuk"
           }
         },
         "vi": {
@@ -33402,7 +33402,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Suono"
           }
         },
         "pt-PT": {
@@ -33567,31 +33567,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Начать калибровку сейчас"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Start nu de kalibratie"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Kalibrasyonu Şimdi Başlatın"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Začnite umerjanje zdaj"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Spustite kalibráciu"
           }
         },
         "vi": {
@@ -33615,7 +33615,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Inizia subito la calibrazione"
           }
         },
         "pt-PT": {
@@ -34101,31 +34101,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Запуск"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Opstarten"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Başlangıç"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Zagon"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Spustenie"
           }
         },
         "vi": {
@@ -34149,7 +34149,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Avvio"
           }
         },
         "pt-PT": {
@@ -35597,31 +35597,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis Настройки"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis-instellingen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis Ayarları"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis nastavitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Nastavenia Stasis"
           }
         },
         "vi": {
@@ -35645,7 +35645,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis Impostazioni"
           }
         },
         "pt-PT": {
@@ -35917,31 +35917,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Фоновый помощник Stasis был успешно одобрен, и теперь фоновая зарядка активна!"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Stasis-achtergrondhelper is met succes goedgekeurd en opladen op de achtergrond is nu actief!"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Stasis arka plan yardımcısı başarıyla onaylandı ve arka planda şarj etme artık etkin!"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Pomočnik v ozadju Stasis je bil uspešno odobren in polnjenje v ozadju je zdaj aktivno!"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Pomocník na pozadí Stasis bol úspešne schválený a nabíjanie na pozadí je teraz aktívne!"
           }
         },
         "vi": {
@@ -35965,7 +35965,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "L'assistente in background Stasis è stato approvato con successo e la ricarica in background è ora attiva!"
           }
         },
         "pt-PT": {
@@ -36130,31 +36130,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis еще не одобрен. \n\nВключите переключатель Stasis в разделе «Фоновая активность приложения» в настройках элементов входа. Вы также можете убедиться, что Stasis добавлен в «Открыть при входе в систему»."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis is nog niet goedgekeurd.\n\n Schakel de schakelaar voor Stasis in onder 'App-achtergrondactiviteit' in de instellingen voor inlogitems. Mogelijk wilt u er ook voor zorgen dat Stasis wordt toegevoegd aan 'Openen bij inloggen'."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis henüz onaylanmadı.\n\nLütfen Giriş Öğeleri ayarlarında 'Uygulama Arka Plan Etkinliği' altında Stasis geçişini etkinleştirin. Ayrıca Stasis'in 'Giriş Sırasında Aç' seçeneğine eklendiğinden emin olmak isteyebilirsiniz."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis še ni bil odobren.\n\nOmogočite preklop za Stasis pod »Dejavnost v ozadju aplikacije« v nastavitvah elementov za prijavo. Morda boste želeli tudi zagotoviti, da je Stasis dodan v »Odpri ob prijavi«."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis ešte nebola schválená.\n\nPovoľte prepínač pre Stasis v časti „Aktivita na pozadí aplikácie“ v nastaveniach položiek prihlásenia. Môžete sa tiež uistiť, že Stasis je pridaná do „Otvoriť pri prihlásení“."
           }
         },
         "vi": {
@@ -36178,7 +36178,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis non è stato ancora approvato.\n\nAbilita l'interruttore per Stasis in \"Attività in background dell'app\" nelle impostazioni degli Elementi di accesso. Potresti anche voler assicurarti che Stasis venga aggiunto a \"Apri all'accesso\"."
           }
         },
         "pt-PT": {
@@ -36343,31 +36343,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis потерял соединение со своим фоновым помощником. Перейдите в «Системные настройки» > «Основные» > «Элементы входа», выключите и снова включите Stasis в разделе «Разрешить в фоновом режиме» и перезапустите приложение."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis heeft de verbinding met zijn achtergrondhelper verloren. Ga naar Systeeminstellingen > Algemeen > Inlogitems, schakel Stasis uit en weer in onder 'Toestaan ​​op de achtergrond' en start de app opnieuw."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis arka plandaki yardımcıyla bağlantısını kaybetti. Lütfen Sistem Ayarları > Genel > Giriş Öğeleri'ne gidin, 'Arka Planda İzin Ver' seçeneğinin altında Stasis'i kapatıp tekrar açın ve uygulamayı yeniden başlatın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis je izgubil povezavo s svojim pomočnikom v ozadju. Pojdite v Sistemske nastavitve > Splošno > Elementi za prijavo, izklopite in znova vklopite Stasis pod »Dovoli v ozadju« ter znova zaženite aplikacijo."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis stratila spojenie so svojím pomocníkom na pozadí. Prejdite do Nastavenia systému > Všeobecné > Položky prihlásenia, vypnite a znova zapnite Stasis v časti „Povoliť na pozadí“ a reštartujte aplikáciu."
           }
         },
         "vi": {
@@ -36391,7 +36391,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis ha perso la connessione con il suo helper in background. Vai su Impostazioni di sistema > Generali > Elementi di accesso, spegni e riaccendi Stasis in \"Consenti in background\" e riavvia l'app."
           }
         },
         "pt-PT": {
@@ -36556,31 +36556,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis использует Sparkle для обработки автоматических обновлений."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis gebruikt Sparkle om automatische updates af te handelen."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis, otomatik güncellemeleri yönetmek için Sparkle'ı kullanıyor."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis uporablja Sparkle za upravljanje samodejnih posodobitev."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis používa Sparkle na spracovanie automatických aktualizácií."
           }
         },
         "vi": {
@@ -36604,7 +36604,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis utilizza Sparkle per gestire gli aggiornamenti automatici."
           }
         },
         "pt-PT": {
@@ -37194,31 +37194,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Системные настройки по умолчанию"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Systeemstandaard"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Sistem Varsayılanı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Sistemsko privzeto"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Predvolené nastavenie systému"
           }
         },
         "vi": {
@@ -37242,7 +37242,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Predefinito del sistema"
           }
         },
         "pt-PT": {
@@ -37300,19 +37300,19 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "Температура"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "Temperatuur"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "Sıcaklık"
           }
         },
         "sl": {
@@ -37324,7 +37324,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "Teplota"
           }
         },
         "vi": {
@@ -37513,31 +37513,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Предел температуры"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Temperatuurlimiet"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Sıcaklık sınırı"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Temperaturna omejitev"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Teplotný limit"
           }
         },
         "vi": {
@@ -37561,7 +37561,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Limite di temperatura"
           }
         },
         "pt-PT": {
@@ -38261,31 +38261,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Вспомогательный демон работает в фоновом режиме для управления состояниями зарядки аккумулятора. \n\nПримечание: macOS намеренно сохраняет приложения в списке «Фоновая активность приложений» (Настройки системы) даже после того, как их фоновый помощник не зарегистрирован. Как только вы нажмете «Удалить», помощник действительно отключится, но macOS сохранит Stasis видимым в этом списке до тех пор, пока само приложение не будет удалено с вашего Mac."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "De helper-daemon draait op de achtergrond om de oplaadstatus van de batterij te beheren.\n\nOpmerking: macOS bewaart met opzet apps in de lijst 'App-achtergrondactiviteit' (Systeeminstellingen), zelfs nadat hun achtergrondhelper niet meer is geregistreerd. Zodra u op Verwijderen klikt, is de helper echt uitgeschakeld, maar macOS houdt Stasis zichtbaar in die lijst totdat de app zelf van uw Mac wordt verwijderd."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Yardımcı arka plan programı, pil şarj durumlarını yönetmek için arka planda çalışır.\n\nNot: macOS, arka plandaki yardımcının kaydı silindikten sonra bile uygulamaları kasıtlı olarak \"Uygulama Arka Plan Etkinliği\" listesinde (Sistem Ayarları) tutar. Kaldır'a tıkladığınızda yardımcı gerçekten devre dışı bırakılır, ancak macOS, uygulamanın kendisi Mac'inizden silinene kadar Stasis'i bu listede görünür tutacaktır."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Pomožni demon deluje v ozadju, da upravlja stanja polnjenja baterije.\n\nOpomba: macOS namenoma obdrži aplikacije na seznamu »Dejavnost v ozadju aplikacije« (sistemske nastavitve), tudi če je njihov pomočnik v ozadju odjavljen. Ko kliknete Odstrani, je pomočnik resnično onemogočen, vendar bo macOS ohranil Stasis viden na tem seznamu, dokler sama aplikacija ne bo izbrisana iz vašega Maca."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Pomocný démon beží na pozadí, aby spravoval stavy nabíjania batérie.\n\nPoznámka: macOS zámerne uchováva aplikácie v zozname „Aktivita aplikácie na pozadí“ (Nastavenia systému) aj po zrušení registrácie ich pomocníka na pozadí. Po kliknutí na položku Odinštalovať sa pomocník skutočne deaktivuje, ale macOS ponechá Stasis viditeľnú v tomto zozname, kým sa samotná aplikácia neodstráni z vášho Macu."
           }
         },
         "vi": {
@@ -38309,7 +38309,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Il demone helper viene eseguito in background per gestire gli stati di ricarica della batteria.\n\nNota: macOS conserva intenzionalmente le app nell'elenco \"Attività in background delle app\" (Impostazioni di sistema) anche dopo che il loro helper in background non è registrato. Dopo aver fatto clic su Disinstalla, l'helper viene veramente disabilitato, ma macOS manterrà Stasis visibile nell'elenco finché l'app stessa non verrà eliminata dal tuo Mac."
           }
         },
         "pt-PT": {
@@ -38367,31 +38367,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Порог ниже лимита"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Drempel onder limiet"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Limitin altındaki eşik"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Prag pod mejo"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Prah pod limitom"
           }
         },
         "vi": {
@@ -38415,7 +38415,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Soglia sotto il limite"
           }
         },
         "pt-PT": {
@@ -38473,31 +38473,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Оставшееся время"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Resterende tijd"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Kalan Süre"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Preostali čas"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Zostávajúci čas"
           }
         },
         "vi": {
@@ -38521,7 +38521,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Tempo rimanente"
           }
         },
         "pt-PT": {
@@ -38579,31 +38579,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Время суток"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Tijd van de dag"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Günün Saati"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Čas dneva"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Čas dňa"
           }
         },
         "vi": {
@@ -38627,7 +38627,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Ora del giorno"
           }
         },
         "pt-PT": {
@@ -38685,31 +38685,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Время до разрядки"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Tijd tot ontladen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Deşarja kalan süre"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Čas do izpraznitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Čas do vybitia"
           }
         },
         "vi": {
@@ -38733,7 +38733,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Tempo alla scarica"
           }
         },
         "pt-PT": {
@@ -38886,7 +38886,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Suggerimento: controlla Impostazioni di sistema -> Generale -> Elementi di accesso. Assicurarsi che Stasis possa essere eseguito in background. Se è già attivo, prova a spegnerlo e riaccenderlo."
           }
         },
         "ja": {
@@ -38904,7 +38904,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Tip: Controleer Systeeminstellingen -> Algemeen -> Inlogitems. Zorg ervoor dat Stasis op de achtergrond mag draaien. Als het al is ingeschakeld, probeer het dan uit en weer in te schakelen."
           }
         },
         "pt-BR": {
@@ -38922,25 +38922,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Совет: проверьте «Настройки системы» -> «Основные» -> «Элементы входа». Убедитесь, что Stasis разрешено работать в фоновом режиме. Если он уже включен, попробуйте выключить и включить его снова."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Tip: Skontrolujte Nastavenia systému -> Všeobecné -> Položky prihlásenia. Uistite sa, že Stasis môže bežať na pozadí. Ak je už zapnutý, skúste ho vypnúť a znova zapnúť."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Nasvet: Preverite sistemske nastavitve -> Splošno -> Elementi za prijavo. Zagotovite, da je Stasis dovoljeno izvajati v ozadju. Če je že vklopljen, ga poskusite izklopiti in znova vklopiti."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "İpucu: Sistem Ayarları -> Genel -> Giriş Öğelerini kontrol edin. Stasis'in arka planda çalışmasına izin verildiğinden emin olun. Zaten açıksa, kapatıp tekrar açmayı deneyin."
           }
         },
         "vi": {
@@ -40395,31 +40395,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Зарядка до лимита"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Opladen tot limiet"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Sınıra Kadar Şarj"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Polnjenje do omejitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Nabitie po limit"
           }
         },
         "vi": {
@@ -40443,7 +40443,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Ricarica fino al limite"
           }
         },
         "pt-PT": {
@@ -41248,31 +41248,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Удалить вспомогательный демон"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Helper-daemon verwijderen"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Yardımcı arka plan programını kaldır"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Odstrani pomožni demon"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Odinštalovať pomocného démona"
           }
         },
         "vi": {
@@ -41296,7 +41296,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Disinstallare il demone helper"
           }
         },
         "pt-PT": {
@@ -41343,7 +41343,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Sconosciuto"
           }
         },
         "ja": {
@@ -41361,7 +41361,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Onbekend"
           }
         },
         "pt-BR": {
@@ -41379,25 +41379,25 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Неизвестно"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Neznámy"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Neznano"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Bilinmiyor"
           }
         },
         "vi": {
@@ -41568,31 +41568,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Обновления"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Updates"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Güncellemeler"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Posodobitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Aktualizácie"
           }
         },
         "vi": {
@@ -41616,7 +41616,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Aggiornamenti"
           }
         },
         "pt-PT": {
@@ -41674,31 +41674,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Время работы"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Uptime"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Çalışma süresi"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Uptime"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Uptime"
           }
         },
         "vi": {
@@ -41722,7 +41722,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Tempo di attività"
           }
         },
         "pt-PT": {
@@ -41780,31 +41780,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Использовать аппаратный процент заряда"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Hardware-batterijpercentage gebruiken"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Donanım pil yüzdesini kullan"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Uporabi strojni odstotek baterije"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Použiť hardvérové percento batérie"
           }
         },
         "vi": {
@@ -41828,7 +41828,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Usa percentuale batteria hardware"
           }
         },
         "pt-PT": {
@@ -41886,31 +41886,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Использовать необработанное значение состояния оборудования"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Ruwe hardwareconditie gebruiken"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Ham donanım sağlık değerini kullan"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Uporabi neobdelano stanje strojne opreme"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Použiť nespracovaný stav hardvéru"
           }
         },
         "vi": {
@@ -41934,7 +41934,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Usa lo stato hardware grezzo"
           }
         },
         "pt-PT": {
@@ -41992,31 +41992,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Используйте необработанный процент заряда батареи вместо калиброванного значения macOS."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Gebruik het onbewerkte batterijpercentage in plaats van de door macOS gekalibreerde waarde."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "macOS kalibre edilmiş değer yerine ham pil yüzdesini kullanın."
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Uporabite neobdelani odstotek baterije namesto umerjene vrednosti za macOS."
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Namiesto kalibrovanej hodnoty pre macOS použite nespracované percento batérie."
           }
         },
         "vi": {
@@ -42040,7 +42040,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Utilizza la percentuale grezza della batteria anziché il valore calibrato di macOS."
           }
         },
         "pt-PT": {
@@ -42204,31 +42204,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "Посмотреть на GitHub"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "Bekijk op GitHub"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "GitHub'da görüntüle"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "Ogled na GitHub"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "Zobraziť na GitHub"
           }
         },
         "vi": {
@@ -42252,7 +42252,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "Visualizza su GitHub"
           }
         },
         "pt-PT": {
@@ -42310,31 +42310,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Оформление"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Weergave"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Görünüm"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Videz"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Vzhľad"
           }
         },
         "vi": {
@@ -42358,7 +42358,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Aspetto"
           }
         },
         "pt-PT": {
@@ -42416,31 +42416,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Еженедельно"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Wekelijks"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Haftalık"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Tedensko"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Týždenne"
           }
         },
         "vi": {
@@ -42464,7 +42464,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Settimanale"
           }
         },
         "pt-PT": {
@@ -42629,31 +42629,31 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "При обнаружении обновлений"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "Wanneer er updates zijn gevonden"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "Güncellemeler bulunduğunda"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "Ko so najdene posodobitve"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "Keď sa nájdu aktualizácie"
           }
         },
         "vi": {
@@ -42677,7 +42677,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "Quando vengono trovati gli aggiornamenti"
           }
         },
         "pt-PT": {

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -220,91 +220,91 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld T %lld Std. %lld Min."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld h %lld min"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld h %lld min"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld j %lld h %lld min"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld g %lld h %lld min"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld日 %lld時間 %lld分"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld일 %lld시간 %lld분"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld u %lld min"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld h %lld min"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld h %lld min"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld д %lld ч %lld мин"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld h %lld min"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld d %lld h %lld min"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld g %lld sa %lld dk"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld ngày %lld giờ %lld phút"
           }
         },
         "zh-Hans": {
@@ -316,7 +316,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldd %lldh %lldm"
+            "value": "%lld 天 %lld 小時 %lld 分鐘"
           }
         }
       }
@@ -327,91 +327,91 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld Std. %lld Min."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld時間 %lld分"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld시간 %lld분"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld u %lld min"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld ч %lld мин"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld h %lld min"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld sa %lld dk"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld giờ %lld phút"
           }
         },
         "zh-Hans": {
@@ -423,7 +423,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldh %lldm"
+            "value": "%lld 小時 %lld 分鐘"
           }
         }
       }
@@ -434,91 +434,91 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld Min."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld分"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld분"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld мин"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld min"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld dk"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld phút"
           }
         },
         "zh-Hans": {
@@ -530,7 +530,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lldm"
+            "value": "%lld 分鐘"
           }
         }
       }
@@ -1714,13 +1714,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de alimentación del adaptador"
+            "value": "Métricas de potencia del adaptador"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de alimentación del adaptador"
+            "value": "Métricas de potencia del adaptador"
           }
         },
         "ja": {
@@ -1798,13 +1798,13 @@
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Métricas de potência do adaptador"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Métricas de potência do adaptador"
           }
         }
       }
@@ -4794,13 +4794,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energía de la batería"
+            "value": "Métricas de potencia de la batería"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energía de la batería"
+            "value": "Métricas de potencia de la batería"
           }
         },
         "ja": {
@@ -4818,7 +4818,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "電池電量指標"
+            "value": "電池功率指標"
           }
         },
         "ru": {
@@ -4854,7 +4854,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Số liệu năng lượng pin"
+            "value": "Chỉ số công suất pin"
           }
         },
         "ko": {
@@ -4878,13 +4878,13 @@
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Métricas de potência da bateria"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Métricas de potência da bateria"
           }
         }
       }
@@ -10780,7 +10780,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "控制 Stasis 何時向您發送通知。"
+            "value": "控制 Stasis 傳送通知的時機。"
           }
         },
         "ru": {
@@ -11724,7 +11724,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "開発者"
           }
         },
         "zh-Hans": {
@@ -11736,49 +11736,49 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "開發者"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Разработчик"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Ontwikkelaar"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Geliştirici"
           }
         },
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Razvijalec"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Vývojár"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Nhà phát triển"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "개발자"
           }
         },
         "fr": {
@@ -11790,19 +11790,19 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Sviluppatore"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Programador"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Developer"
+            "value": "Desenvolvedor"
           }
         }
       }
@@ -26823,25 +26823,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Macht"
+            "value": "Leistung"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "poder"
+            "value": "Potencia"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "poder"
+            "value": "Potencia"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "パワー"
+            "value": "電力"
           }
         },
         "zh-Hans": {
@@ -26853,7 +26853,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "電源"
+            "value": "功率"
           }
         },
         "ru": {
@@ -26865,7 +26865,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Macht"
+            "value": "Vermogen"
           }
         },
         "tr": {
@@ -26883,19 +26883,19 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sila"
+            "value": "Výkon"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "quyền lực"
+            "value": "Công suất"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "힘"
+            "value": "전력"
           }
         },
         "fr": {
@@ -26913,13 +26913,13 @@
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Potência"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Potência"
           }
         }
       }
@@ -27353,19 +27353,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nur Strom"
+            "value": "Nur Netzstrom"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sólo energía"
+            "value": "Solo alimentación"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sólo energía"
+            "value": "Solo alimentación"
           }
         },
         "ja": {
@@ -27377,7 +27377,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅接通电源时"
+            "value": "仅电源"
           }
         },
         "zh-Hant": {
@@ -27395,7 +27395,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alleen stroom"
+            "value": "Alleen netvoeding"
           }
         },
         "tr": {
@@ -27443,13 +27443,13 @@
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Apenas alimentação"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas energia"
+            "value": "Somente alimentação"
           }
         }
       }
@@ -27543,7 +27543,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte di energia"
+            "value": "Fonte di alimentazione"
           }
         },
         "pt-PT": {
@@ -27725,13 +27725,13 @@
         "sl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vir energije"
+            "value": "Vir napajanja"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zdroj energie"
+            "value": "Zdroj napájania"
           }
         },
         "vi": {
@@ -27755,7 +27755,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte di energia"
+            "value": "Fonte di alimentazione"
           }
         },
         "pt-PT": {
@@ -28445,7 +28445,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "退出Stasis？"
+            "value": "結束 Stasis？"
           }
         },
         "ru": {
@@ -38958,7 +38958,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "提示：檢查系統設定->常規->登入項目。確保允許 Stasis 在背景運行。如果它已經打開，請嘗試將其關閉然後再次打開。"
+            "value": "提示：請檢查「系統設定」->「一般」->「登入項目」。確認已允許 Stasis 在背景執行。若已開啟，請嘗試先關閉再重新開啟。"
           }
         }
       }

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1508,7 +1508,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ação necessária"
+            "value": "Acción requerida"
           }
         },
         "fr": {
@@ -1708,19 +1708,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Adapterleistungsmetriken"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Métricas de alimentación del adaptador"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Métricas de alimentación del adaptador"
           }
         },
         "ja": {
@@ -1786,7 +1786,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Mesures de puissance de l'adaptateur"
           }
         },
         "it": {
@@ -1814,19 +1814,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Die Adaptersteuerung wird auf diesem Gerät nicht unterstützt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "El control del adaptador no es compatible con este dispositivo."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "El control del adaptador no es compatible con este dispositivo."
           }
         },
         "ja": {
@@ -1892,7 +1892,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Le contrôle de l'adaptateur n'est pas pris en charge sur cet appareil."
           }
         },
         "it": {
@@ -2347,25 +2347,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Alle Einstellungen wurden erfolgreich auf ihre Standardeinstellungen zurückgesetzt. Die App wird nun neu gestartet."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Todas las preferencias se han restaurado exitosamente a sus valores predeterminados. La aplicación ahora se reiniciará."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Todas las preferencias se han restaurado exitosamente a sus valores predeterminados. La aplicación ahora se reiniciará."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Toutes les préférences ont été restaurées avec succès à leurs valeurs par défaut. L'application va maintenant redémarrer."
           }
         },
         "it": {
@@ -2572,7 +2572,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sempre"
+            "value": "Siempre"
           }
         },
         "ja": {
@@ -3516,19 +3516,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Hintergrund-Hilfsdienst getrennt"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Servicio auxiliar en segundo plano desconectado"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Servicio auxiliar en segundo plano desconectado"
           }
         },
         "ja": {
@@ -3594,7 +3594,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Service auxiliaire en arrière-plan déconnecté"
           }
         },
         "it": {
@@ -4364,19 +4364,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Batteriekalibrierung fällig"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Calibración de batería pendiente"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Calibración de batería pendiente"
           }
         },
         "ja": {
@@ -4442,7 +4442,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Étalonnage de la batterie dû"
           }
         },
         "it": {
@@ -4682,19 +4682,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Nur Batterie"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Sólo batería"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Sólo batería"
           }
         },
         "ja": {
@@ -4760,7 +4760,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Batterie uniquement"
           }
         },
         "it": {
@@ -4788,19 +4788,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Batterieleistungsmetriken"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Métricas de energía de la batería"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Métricas de energía de la batería"
           }
         },
         "ja": {
@@ -4866,7 +4866,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Mesures de puissance de la batterie"
           }
         },
         "it": {
@@ -4894,19 +4894,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Batteriemesswert"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Lectura de la batería"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Lectura de la batería"
           }
         },
         "ja": {
@@ -4972,7 +4972,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Relevé de batterie"
           }
         },
         "it": {
@@ -5106,19 +5106,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Akku- und Ladekontrolle für MacBook."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Control de batería y carga para MacBook."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Control de batería y carga para MacBook."
           }
         },
         "ja": {
@@ -5184,7 +5184,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Contrôle de la batterie et de la charge pour MacBook."
           }
         },
         "it": {
@@ -5426,19 +5426,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Die Batteriekalibrierung wird auf diesem Gerät nicht unterstützt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "La calibración de la batería no es compatible con este dispositivo."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "La calibración de la batería no es compatible con este dispositivo."
           }
         },
         "ja": {
@@ -5504,7 +5504,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "L'étalonnage de la batterie n'est pas pris en charge sur cet appareil."
           }
         },
         "it": {
@@ -5956,19 +5956,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Bei der Entwicklung wurde der Schwerpunkt auf praktischen Batteriezustand und Ladeabläufe gelegt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Creado centrándose en el estado práctico de la batería y los flujos de trabajo de carga."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Creado centrándose en el estado práctico de la batería y los flujos de trabajo de carga."
           }
         },
         "ja": {
@@ -6034,7 +6034,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Construit en mettant l’accent sur l’état pratique de la batterie et les flux de travail de charge."
           }
         },
         "it": {
@@ -6276,19 +6276,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Kalibrieren (Aufladen auf %@)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Calibración (cargando a %@)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Calibración (cargando a %@)"
           }
         },
         "ja": {
@@ -6354,7 +6354,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Calibrage (chargement sur %@)"
           }
         },
         "it": {
@@ -6382,19 +6382,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Kalibrieren (Aufladen)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Calibrando (Cargando)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Calibrando (Cargando)"
           }
         },
         "ja": {
@@ -6460,7 +6460,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Calibrage (chargement)"
           }
         },
         "it": {
@@ -6489,19 +6489,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Kalibrieren (Entladen nach %@)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Calibración (Descarga a %@)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Calibración (Descarga a %@)"
           }
         },
         "ja": {
@@ -6567,7 +6567,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Calibrage (décharge vers %@)"
           }
         },
         "it": {
@@ -6595,19 +6595,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Kalibrieren (Entladen)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Calibración (descarga)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Calibración (descarga)"
           }
         },
         "ja": {
@@ -6673,7 +6673,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Calibrage (décharge)"
           }
         },
         "it": {
@@ -6701,19 +6701,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Kalibrieren (Pause – Einstecken)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Calibración (en pausa - enchufar)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Calibración (en pausa - enchufar)"
           }
         },
         "ja": {
@@ -6779,7 +6779,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Calibrage (Pause - Brancher)"
           }
         },
         "it": {
@@ -6808,19 +6808,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Kalibrieren (Ruhezustand bei %@)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Calibrando (Reposando en %@)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Calibrando (Reposando en %@)"
           }
         },
         "ja": {
@@ -6886,7 +6886,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Étalonnage (au repos à %@)"
           }
         },
         "it": {
@@ -6914,19 +6914,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Kalibrieren (Ruhen)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Calibrar (reposar)"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Calibrar (reposar)"
           }
         },
         "ja": {
@@ -6992,7 +6992,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Calibrage (au repos)"
           }
         },
         "it": {
@@ -8087,19 +8087,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Ladelimit überschreiben"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Anulación del límite de carga"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Anulación del límite de carga"
           }
         },
         "ja": {
@@ -8165,7 +8165,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Contournement de la limite de charge"
           }
         },
         "it": {
@@ -8833,19 +8833,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Die Ladeverwaltung wird auf diesem Gerät nicht unterstützt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "La gestión de carga no es compatible con este dispositivo."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "La gestión de carga no es compatible con este dispositivo."
           }
         },
         "ja": {
@@ -8911,7 +8911,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "La gestion de la charge n’est pas prise en charge sur cet appareil."
           }
         },
         "it": {
@@ -9152,19 +9152,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Die Ladesteuerung wird auf diesem Gerät nicht unterstützt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "El control de carga no es compatible con este dispositivo."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "El control de carga no es compatible con este dispositivo."
           }
         },
         "ja": {
@@ -9230,7 +9230,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Le contrôle de charge n'est pas pris en charge sur cet appareil."
           }
         },
         "it": {
@@ -9685,25 +9685,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Bis zum Ladelimit laden"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Cargando hasta el límite"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Cargando hasta el límite"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Charge jusqu’à la limite"
           }
         },
         "it": {
@@ -10537,7 +10537,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "Gemeinschaft"
           }
         },
         "es": {
@@ -11175,19 +11175,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Daemon-Fehler – Einstellungen nicht synchronisiert"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Error de demonio: configuración no sincronizada"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Error de demonio: configuración no sincronizada"
           }
         },
         "ja": {
@@ -11253,7 +11253,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Erreur de démon – Paramètres non synchronisés"
           }
         },
         "it": {
@@ -12676,7 +12676,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar"
+            "value": "Descargando"
           }
         },
         "fr": {
@@ -13089,19 +13089,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Zeigt den Batterieprozentsatz neben oder innerhalb des Menüleistensymbols an."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Muestra el porcentaje de batería al lado o dentro del ícono de la barra de menú."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Muestra el porcentaje de batería al lado o dentro del ícono de la barra de menú."
           }
         },
         "ja": {
@@ -13167,7 +13167,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Affichez le pourcentage de batterie à côté ou à l’intérieur de l’icône de la barre de menu."
           }
         },
         "it": {
@@ -15329,19 +15329,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Segelmodus aktivieren"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Activar modo navegación"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Activar modo navegación"
           }
         },
         "ja": {
@@ -15407,7 +15407,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Activer le mode Navigation"
           }
         },
         "it": {
@@ -16393,25 +16393,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Ladehilfe konnte nicht installiert werden"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "No se pudo instalar el asistente de carga"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "No se pudo instalar el asistente de carga"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Échec de l'installation de l'assistant de chargement"
           }
         },
         "it": {
@@ -16500,25 +16500,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Ladehilfe konnte nicht deinstalliert werden"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "No se pudo desinstalar el asistente de carga"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "No se pudo desinstalar el asistente de carga"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Échec de la désinstallation de l'assistant de chargement"
           }
         },
         "it": {
@@ -16607,19 +16607,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Stellen Sie für eine zuverlässige Ladeverwaltung sicher, dass „Akkuladung optimieren“ deaktiviert ist und Apples natives Ladelimit unter **Systemeinstellungen → Akku** genau bei **%@** liegt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Para una gestión de carga confiable, asegúrese de que \"Optimizar la carga de la batería\" esté desactivado y que el límite de carga nativo de Apple esté exactamente en **%@** en **Configuración del sistema → Batería**."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Para una gestión de carga confiable, asegúrese de que \"Optimizar la carga de la batería\" esté desactivado y que el límite de carga nativo de Apple esté exactamente en **%@** en **Configuración del sistema → Batería**."
           }
         },
         "ja": {
@@ -16685,7 +16685,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Pour une gestion fiable de la charge, assurez-vous que « Optimiser la charge de la batterie » est désactivé et que la limite de charge native d'Apple est exactement à **%@** dans **Paramètres système → Batterie**."
           }
         },
         "it": {
@@ -17577,7 +17577,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Geral"
+            "value": "General"
           }
         },
         "ja": {
@@ -17671,19 +17671,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Allgemeine Informationen zum System- und Batteriestatus werden im Dropdown-Menü angezeigt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Información general del estado del sistema y de la batería que se muestra en el menú desplegable."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Información general del estado del sistema y de la batería que se muestra en el menú desplegable."
           }
         },
         "ja": {
@@ -17749,7 +17749,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Informations générales sur l'état du système et de la batterie affichées dans le menu déroulant."
           }
         },
         "it": {
@@ -18210,13 +18210,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "verde"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "verde"
           }
         },
         "ja": {
@@ -18856,7 +18856,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado do auxiliar"
+            "value": "Estado del asistente"
           }
         },
         "fr": {
@@ -18951,25 +18951,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Hilfsdaemon erfolgreich installiert."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "El demonio auxiliar se instaló exitosamente."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "El demonio auxiliar se instaló exitosamente."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Démon d'assistance installé avec succès."
           }
         },
         "it": {
@@ -19058,25 +19058,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Hilfsdaemon erfolgreich deinstalliert. Die App wird nun neu gestartet."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "El demonio auxiliar se desinstaló exitosamente. La aplicación ahora se reiniciará."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "El demonio auxiliar se desinstaló exitosamente. La aplicación ahora se reiniciará."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Le démon d'assistance a été désinstallé avec succès. L'application va maintenant redémarrer."
           }
         },
         "it": {
@@ -20545,19 +20545,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Bei der Anmeldung starten"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Iniciar al iniciar sesión"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Iniciar al iniciar sesión"
           }
         },
         "ja": {
@@ -20623,7 +20623,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Lancer à la connexion"
           }
         },
         "it": {
@@ -21502,19 +21502,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Die MagSafe-LED-Steuerung wird auf diesem Gerät nicht unterstützt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "El control LED MagSafe no es compatible con este dispositivo."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "El control LED MagSafe no es compatible con este dispositivo."
           }
         },
         "ja": {
@@ -21580,7 +21580,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Le contrôle LED MagSafe n'est pas pris en charge sur cet appareil."
           }
         },
         "it": {
@@ -22248,19 +22248,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Menüleistensymbol"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Icono de la barra de menú"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Icono de la barra de menú"
           }
         },
         "ja": {
@@ -22326,7 +22326,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Icône de la barre de menus"
           }
         },
         "it": {
@@ -22354,19 +22354,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Menüsteuerung"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Controles de menú"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Controles de menú"
           }
         },
         "ja": {
@@ -22432,7 +22432,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Commandes de menu"
           }
         },
         "it": {
@@ -24909,19 +24909,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Öffnen Sie Einstellungen"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Abrir configuración"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Abrir configuración"
           }
         },
         "ja": {
@@ -24987,7 +24987,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Ouvrir les paramètres"
           }
         },
         "it": {
@@ -25443,7 +25443,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Orange"
           }
         },
         "es": {
@@ -25521,7 +25521,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "Orange"
           }
         },
         "it": {
@@ -25549,19 +25549,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Ursprünglich auf einer Open-Source-Basis entwickelt und dann mit neuen Funktionen weiterentwickelt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Originalmente bifurcado a partir de una base de código abierto, luego se desarrolló aún más con nuevas funciones."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Originalmente bifurcado a partir de una base de código abierto, luego se desarrolló aún más con nuevas funciones."
           }
         },
         "ja": {
@@ -25627,7 +25627,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Initialement dérivé d'une base open source, puis développé avec de nouvelles fonctionnalités."
           }
         },
         "it": {
@@ -25761,19 +25761,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Textzeile für Ausgabeports"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Fila de texto de puertos de salida"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Fila de texto de puertos de salida"
           }
         },
         "ja": {
@@ -25839,7 +25839,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Ligne de texte des ports de sortie"
           }
         },
         "it": {
@@ -26187,25 +26187,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Bitte öffnen Sie Systemeinstellungen -> Allgemein -> Anmeldeelemente und lassen Sie Stasis im Hintergrund laufen. Versuchen Sie es dann erneut."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Abra Configuración del sistema -> General -> Elementos de inicio de sesión y permita que Stasis se ejecute en segundo plano, luego inténtelo nuevamente."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Abra Configuración del sistema -> General -> Elementos de inicio de sesión y permita que Stasis se ejecute en segundo plano, luego inténtelo nuevamente."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Veuillez ouvrir Paramètres système -> Général -> Éléments de connexion et autoriser Stasis à s'exécuter en arrière-plan, puis réessayez."
           }
         },
         "it": {
@@ -26823,19 +26823,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Macht"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "poder"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "poder"
           }
         },
         "ja": {
@@ -26901,7 +26901,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "Puissance"
           }
         },
         "it": {
@@ -27353,19 +27353,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Nur Strom"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Sólo energía"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Sólo energía"
           }
         },
         "ja": {
@@ -27431,7 +27431,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Alimentation uniquement"
           }
         },
         "it": {
@@ -27565,19 +27565,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Stromverteilungsdiagramm"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Diagrama de distribución de energía."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Diagrama de distribución de energía."
           }
         },
         "ja": {
@@ -27643,7 +27643,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Schéma de distribution d'énergie"
           }
         },
         "it": {
@@ -27790,7 +27790,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições repostas"
+            "value": "Preferencias restablecidas"
           }
         },
         "fr": {
@@ -28415,19 +28415,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Stasis beenden?"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "¿Salir de Stasis?"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "¿Salir de Stasis?"
           }
         },
         "ja": {
@@ -28493,7 +28493,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Quitter Stasis ?"
           }
         },
         "it": {
@@ -28521,19 +28521,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Durch das Beenden von Stasis werden die Hintergrundhilfsdienste beendet. Die Grenzwerte und Schutzfunktionen für die Akkuladung funktionieren nicht mehr."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Salir de Stasis detendrá los servicios de ayuda en segundo plano. Los límites y protecciones de carga de la batería ya no funcionarán."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Salir de Stasis detendrá los servicios de ayuda en segundo plano. Los límites y protecciones de carga de la batería ya no funcionarán."
           }
         },
         "ja": {
@@ -28599,7 +28599,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Quitter Stasis arrêtera les services d’assistance en arrière-plan. Les limites de charge et les protections de la batterie ne fonctionneront plus."
           }
         },
         "it": {
@@ -28851,7 +28851,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repor"
+            "value": "Restablecer"
           }
         },
         "ja": {
@@ -29372,19 +29372,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Ausruhen bei %@..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Descansando en %@..."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Descansando en %@..."
           }
         },
         "ja": {
@@ -29450,7 +29450,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Repos à %@..."
           }
         },
         "it": {
@@ -32680,19 +32680,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Manuelle Ladesteuerung anzeigen"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Mostrar controles de carga manual"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Mostrar controles de carga manual"
           }
         },
         "ja": {
@@ -32758,7 +32758,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Afficher les commandes de charge manuelles"
           }
         },
         "it": {
@@ -32892,19 +32892,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Ausgehende Leistung anzeigen"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Mostrar potencia de salida"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Mostrar potencia de salida"
           }
         },
         "ja": {
@@ -32970,7 +32970,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Afficher la puissance de sortie"
           }
         },
         "it": {
@@ -33224,7 +33224,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adiar (1 dia)"
+            "value": "Posponer (1 día)"
           }
         },
         "fr": {
@@ -33650,7 +33650,7 @@
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar agora"
+            "value": "Iniciar ahora"
           }
         },
         "fr": {
@@ -34065,19 +34065,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Autostart"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Inicio"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Inicio"
           }
         },
         "ja": {
@@ -34143,7 +34143,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Démarrage"
           }
         },
         "it": {
@@ -35561,19 +35561,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis-Einstellungen"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Configuración de Stasis"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Configuración de Stasis"
           }
         },
         "ja": {
@@ -35639,7 +35639,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Paramètres Stasis"
           }
         },
         "it": {
@@ -36094,19 +36094,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis wurde noch nicht genehmigt.\n\nBitte aktivieren Sie den Schalter für Stasis unter „App-Hintergrundaktivität“ in den Einstellungen für Anmeldeelemente. Möglicherweise möchten Sie auch sicherstellen, dass Stasis zu „Beim Anmelden öffnen“ hinzugefügt wird."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis aún no ha sido aprobado.\n\nHabilite el interruptor para Stasis en 'Actividad en segundo plano de la aplicación' en la configuración de Elementos de inicio de sesión. También es posible que desee asegurarse de que Stasis se agregue a \"Abrir al iniciar sesión\"."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis aún no ha sido aprobado.\n\nHabilite el interruptor para Stasis en 'Actividad en segundo plano de la aplicación' en la configuración de Elementos de inicio de sesión. También es posible que desee asegurarse de que Stasis se agregue a \"Abrir al iniciar sesión\"."
           }
         },
         "ja": {
@@ -36172,7 +36172,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis n'a pas encore été approuvé.\n\nVeuillez activer le bouton Stasis sous « Activité en arrière-plan de l'application » dans les paramètres des éléments de connexion. Vous souhaiterez peut-être également vous assurer que Stasis est ajouté à « Ouvrir à la connexion »."
           }
         },
         "it": {
@@ -36307,19 +36307,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis hat die Verbindung zu seinem Hintergrundhelfer verloren. Bitte gehen Sie zu Systemeinstellungen > Allgemein > Anmeldeelemente, schalten Sie Stasis unter „Im Hintergrund zulassen“ aus und wieder ein und starten Sie die App neu."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis perdió la conexión con su asistente en segundo plano. Vaya a Configuración del sistema > General > Elementos de inicio de sesión, apague y vuelva a encender Stasis en 'Permitir en segundo plano' y reinicie la aplicación."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis perdió la conexión con su asistente en segundo plano. Vaya a Configuración del sistema > General > Elementos de inicio de sesión, apague y vuelva a encender Stasis en 'Permitir en segundo plano' y reinicie la aplicación."
           }
         },
         "ja": {
@@ -36385,7 +36385,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis a perdu la connexion avec son assistant en arrière-plan. Veuillez accéder à Paramètres système > Général > Éléments de connexion, désactivez et réactivez Stasis sous « Autoriser en arrière-plan » et redémarrez l'application."
           }
         },
         "it": {
@@ -37158,19 +37158,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Systemstandard"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Valor predeterminado del sistema"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Valor predeterminado del sistema"
           }
         },
         "ja": {
@@ -37236,7 +37236,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Système par défaut"
           }
         },
         "it": {
@@ -38225,19 +38225,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Der Hilfsdaemon wird im Hintergrund ausgeführt, um den Batterieladestatus zu verwalten.\n\nHinweis: macOS behält Apps absichtlich in der Liste „App-Hintergrundaktivität“ (Systemeinstellungen) bei, auch wenn ihr Hintergrundhilfsprogramm nicht registriert ist. Sobald Sie auf „Deinstallieren“ klicken, ist der Helfer tatsächlich deaktiviert, aber macOS lässt Stasis in dieser Liste sichtbar, bis die App selbst von Ihrem Mac gelöscht wird."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "El demonio auxiliar se ejecuta en segundo plano para administrar los estados de carga de la batería.\n\nNota: macOS retiene intencionalmente las aplicaciones en la lista \"Actividad en segundo plano de la aplicación\" (Configuración del sistema) incluso después de que su asistente en segundo plano no esté registrado. Una vez que haces clic en Desinstalar, el asistente está realmente deshabilitado, pero macOS mantendrá Stasis visible en esa lista hasta que la aplicación se elimine de tu Mac."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "El demonio auxiliar se ejecuta en segundo plano para administrar los estados de carga de la batería.\n\nNota: macOS retiene intencionalmente las aplicaciones en la lista \"Actividad en segundo plano de la aplicación\" (Configuración del sistema) incluso después de que su asistente en segundo plano no esté registrado. Una vez que haces clic en Desinstalar, el asistente está realmente deshabilitado, pero macOS mantendrá Stasis visible en esa lista hasta que la aplicación se elimine de tu Mac."
           }
         },
         "ja": {
@@ -38303,7 +38303,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Le démon d'assistance s'exécute en arrière-plan pour gérer les états de charge de la batterie.\n\nRemarque : macOS conserve intentionnellement les applications dans la liste « Activité en arrière-plan de l'application » (Paramètres système) même après la désinscription de leur assistant en arrière-plan. Une fois que vous cliquez sur Désinstaller, l'assistant est véritablement désactivé, mais macOS gardera Stasis visible dans cette liste jusqu'à ce que l'application elle-même soit supprimée de votre Mac."
           }
         },
         "it": {
@@ -38543,19 +38543,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Tageszeit"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Hora del día"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Hora del día"
           }
         },
         "ja": {
@@ -38621,7 +38621,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Heure de la journée"
           }
         },
         "it": {
@@ -38649,19 +38649,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Zeit bis zur Entladung"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Tiempo hasta la descarga"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Tiempo hasta la descarga"
           }
         },
         "ja": {
@@ -38727,7 +38727,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Temps avant décharge"
           }
         },
         "it": {
@@ -38862,25 +38862,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Tipp: Überprüfen Sie die Systemeinstellungen -> Allgemein -> Anmeldeelemente. Stellen Sie sicher, dass Stasis im Hintergrund ausgeführt werden darf. Wenn es bereits eingeschaltet ist, versuchen Sie, es aus- und wieder einzuschalten."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Consejo: Verifique Configuración del sistema -> General -> Elementos de inicio de sesión. Asegúrese de que Stasis pueda ejecutarse en segundo plano. Si ya está activado, intente activarlo y desactivarlo nuevamente."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Consejo: Verifique Configuración del sistema -> General -> Elementos de inicio de sesión. Asegúrese de que Stasis pueda ejecutarse en segundo plano. Si ya está activado, intente activarlo y desactivarlo nuevamente."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Astuce : Vérifiez les paramètres système -> Général -> Éléments de connexion. Assurez-vous que Stasis est autorisé à s’exécuter en arrière-plan. S'il est déjà activé, essayez de l'éteindre et de le rallumer."
           }
         },
         "it": {
@@ -41319,25 +41319,25 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Unbekannt"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Desconocido"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Desconocido"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Inconnu"
           }
         },
         "it": {
@@ -41532,7 +41532,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Aktualisierungen"
           }
         },
         "es": {
@@ -41744,19 +41744,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Hardware-Batteriestand verwenden"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Usar el porcentaje de batería del hardware"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Usar el porcentaje de batería del hardware"
           }
         },
         "ja": {
@@ -41822,7 +41822,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Utiliser le pourcentage brut de la batterie"
           }
         },
         "it": {
@@ -41850,19 +41850,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Unverarbeiteten Hardware-Zustand verwenden"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Usar el estado de hardware sin procesar"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Usar el estado de hardware sin procesar"
           }
         },
         "ja": {
@@ -41928,7 +41928,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Utiliser l’état matériel brut"
           }
         },
         "it": {
@@ -41956,19 +41956,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Verwenden Sie den Rohbatterie-Prozentsatz anstelle des von macOS kalibrierten Werts."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Utilice el porcentaje de batería sin procesar en lugar del valor calibrado de macOS."
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Utilice el porcentaje de batería sin procesar en lugar del valor calibrado de macOS."
           }
         },
         "ja": {
@@ -42034,7 +42034,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Utilisez le pourcentage brut de batterie au lieu de la valeur calibrée de macOS."
           }
         },
         "it": {
@@ -42274,19 +42274,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Darstellung"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Visuales"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Visuales"
           }
         },
         "ja": {
@@ -42352,7 +42352,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Apparence"
           }
         },
         "it": {
@@ -42386,13 +42386,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Semanal"
           }
         },
         "es-US": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "Semanal"
           }
         },
         "ja": {

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -40146,7 +40146,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aufladen abgebrochen. Standardlimit wiederhergestellt."
+            "value": "Aufladen auf %@ abgebrochen. Standardlimit wiederhergestellt."
           }
         },
         "es": {
@@ -40188,7 +40188,7 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opladen geannuleerd. Standaardlimiet hervat."
+            "value": "Opladen tot %@ geannuleerd. Standaardlimiet hervat."
           }
         },
         "pt-BR": {
@@ -41522,7 +41522,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "未知的 Stasis 命令: stasis://%"
+            "value": "未知的 Stasis 指令：stasis://%@"
           }
         }
       }
@@ -43127,6 +43127,102 @@
             "state": "translated",
             "value": "打开 Stasis 主仪表板和设置窗口。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haupt-Dashboard und Einstellungsfenster von Stasis öffnen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre el panel principal y la ventana de ajustes de Stasis."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez le tableau de bord principal et la fenêtre des réglages de Stasis."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri il pannello principale e la finestra delle impostazioni di Stasis."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasisのメインダッシュボードと設定ウインドウを開きます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis 기본 대시보드와 설정 창을 엽니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open het hoofddashboard en het instellingenvenster van Stasis."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o painel principal e a janela de ajustes do Stasis."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o painel principal e a janela de definições do Stasis."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть главную панель и окно настроек Stasis."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvorte hlavný panel a okno nastavení Stasis."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odprite glavno nadzorno ploščo in okno z nastavitvami Stasis."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis ana panosunu ve ayarlar penceresini açın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở bảng điều khiển chính và cửa sổ cài đặt Stasis."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟 Stasis 主儀表板和設定視窗。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre el panel principal y la ventana de ajustes de Stasis."
+          }
         }
       }
     },
@@ -43137,6 +43233,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "连接交流电源时启用或停用电池强制放电。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erzwungene Batterieentladung bei angeschlossenem Netzteil aktivieren oder deaktivieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva la descarga forzada de la batería mientras está conectada a la corriente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez ou désactivez la décharge forcée de la batterie lorsque l’adaptateur secteur est branché."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva o disattiva la scarica forzata della batteria quando è collegata all’alimentazione."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電源接続中のバッテリー強制放電を有効または無効にします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전원에 연결된 동안 배터리 강제 방전을 활성화하거나 비활성화합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schakel geforceerd ontladen van de batterij in of uit terwijl de netvoeding is aangesloten."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative ou desative a descarga forçada da bateria enquanto o Mac estiver conectado à energia."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative ou desative a descarga forçada da bateria enquanto o Mac estiver ligado à corrente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить или отключить принудительную разрядку аккумулятора при подключённом питании."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povoľte alebo zakážte nútené vybíjanie batérie pri pripojení k napájaniu."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogočite ali onemogočite prisilno praznjenje baterije, ko je priključeno napajanje."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güce bağlıyken pili zorla boşaltmayı etkinleştirin veya devre dışı bırakın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật hoặc tắt tính năng buộc xả pin khi đang cắm nguồn AC."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連接交流電源時啟用或停用電池強制放電。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva la descarga forzada de la batería mientras está conectada a la corriente."
           }
         }
       }
@@ -43149,6 +43341,102 @@
             "state": "translated",
             "value": "在 Stasis 中开始完整的电池校准周期。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen vollständigen Batteriekalibrierungszyklus in Stasis starten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia un ciclo completo de calibración de la batería en Stasis."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrez un cycle complet d’étalonnage de la batterie dans Stasis."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia un ciclo completo di calibrazione della batteria in Stasis."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasisで完全なバッテリーキャリブレーションサイクルを開始します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis에서 전체 배터리 보정 주기를 시작합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start een volledige batterijkalibratiecyclus in Stasis."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicie um ciclo completo de calibração da bateria no Stasis."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicie um ciclo completo de calibração da bateria no Stasis."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустить полный цикл калибровки аккумулятора в Stasis."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spustite úplný cyklus kalibrácie batérie v Stasis."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zaženite celoten cikel umerjanja baterije v aplikaciji Stasis."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis’te tam bir pil kalibrasyon döngüsü başlatın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bắt đầu một chu kỳ hiệu chỉnh pin đầy đủ trong Stasis."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Stasis 中開始完整的電池校正週期。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia un ciclo completo de calibración de la batería en Stasis."
+          }
         }
       }
     },
@@ -43159,6 +43447,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "取消正在进行的电池校准周期。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen laufenden Batteriekalibrierungszyklus abbrechen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancela un ciclo de calibración de la batería en curso."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulez un cycle d’étalonnage de la batterie en cours."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla un ciclo di calibrazione della batteria in corso."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進行中のバッテリーキャリブレーションサイクルをキャンセルします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진행 중인 배터리 보정 주기를 취소합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleer een actieve batterijkalibratiecyclus."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancele um ciclo de calibração da bateria em andamento."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancele um ciclo de calibração da bateria em curso."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отменить выполняющийся цикл калибровки аккумулятора."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zrušte prebiehajúci cyklus kalibrácie batérie."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prekličite potekajoči cikel umerjanja baterije."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devam eden pil kalibrasyon döngüsünü iptal edin."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy chu kỳ hiệu chỉnh pin đang diễn ra."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消進行中的電池校正週期。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancela un ciclo de calibración de la batería en curso."
           }
         }
       }
@@ -43171,6 +43555,102 @@
             "state": "translated",
             "value": "启用或停用散热保护模式。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hitzeschutzmodus aktivieren oder deaktivieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva el modo de protección térmica."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez ou désactivez le mode de protection thermique."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva o disattiva la modalità di protezione dal calore."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "熱保護モードを有効または無効にします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열 보호 모드를 활성화하거나 비활성화합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schakel de hittebeschermingsmodus in of uit."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative ou desative o modo de proteção térmica."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative ou desative o modo de proteção térmica."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить или отключить режим защиты от перегрева."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povoľte alebo zakážte režim ochrany pred teplom."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogočite ali onemogočite način zaščite pred vročino."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isı Koruma Modu’nu etkinleştirin veya devre dışı bırakın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật hoặc tắt Chế độ Bảo vệ Nhiệt."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用或停用散熱保護模式。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva el modo de protección térmica."
+          }
         }
       }
     },
@@ -43181,6 +43661,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "设置散热保护阈值"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwellenwert für Hitzeschutz festlegen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer el umbral de protección térmica"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir le seuil de protection thermique"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta la soglia di protezione dal calore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "熱保護のしきい値を設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열 보호 임계값 설정"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drempelwaarde voor hittebescherming instellen"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir limite de proteção térmica"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir limiar de proteção térmica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить порог защиты от перегрева"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastaviť prah ochrany pred teplom"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavi prag zaščite pred vročino"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isı Koruma Eşiğini Ayarla"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt Ngưỡng Bảo vệ Nhiệt"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定散熱保護臨界值"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer el umbral de protección térmica"
           }
         }
       }
@@ -43193,6 +43769,102 @@
             "state": "translated",
             "value": "设置散热保护模式的温度阈值（30°C 至 50°C）。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperaturschwellenwert für den Hitzeschutzmodus festlegen (30 °C bis 50 °C)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establece el umbral de temperatura del modo de protección térmica (de 30 °C a 50 °C)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définissez le seuil de température du mode de protection thermique (de 30 °C à 50 °C)."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta la soglia di temperatura della modalità di protezione dal calore (da 30 °C a 50 °C)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "熱保護モードの温度しきい値を設定します（30°C〜50°C）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열 보호 모드의 온도 임계값을 설정합니다(30°C~50°C)."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stel de temperatuurdrempel voor de hittebeschermingsmodus in (30 °C tot 50 °C)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Defina o limite de temperatura do modo de proteção térmica (30 °C a 50 °C)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Defina o limiar de temperatura do modo de proteção térmica (30 °C a 50 °C)."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить температурный порог режима защиты от перегрева (от 30 °C до 50 °C)."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavte teplotný prah režimu ochrany pred teplom (30 °C až 50 °C)."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavite temperaturni prag načina zaščite pred vročino (od 30 °C do 50 °C)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isı Koruma Modu sıcaklık eşiğini ayarlayın (30°C - 50°C)."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt ngưỡng nhiệt độ cho Chế độ Bảo vệ Nhiệt (30°C đến 50°C)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定散熱保護模式的溫度臨界值（30°C 至 50°C）。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establece el umbral de temperatura del modo de protección térmica (de 30 °C a 50 °C)."
+          }
         }
       }
     },
@@ -43203,6 +43875,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "启用或停用自定义 MagSafe LED 颜色指示。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefinierte MagSafe-LED-Farbanzeige aktivieren oder deaktivieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva la indicación de color personalizada del LED MagSafe."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez ou désactivez l’indication de couleur personnalisée de la LED MagSafe."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva o disattiva l’indicazione del colore personalizzato del LED MagSafe."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MagSafe LEDのカスタムカラー表示を有効または無効にします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 MagSafe LED 색상 표시를 활성화하거나 비활성화합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schakel de aangepaste kleurindicatie van de MagSafe-led in of uit."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative ou desative a indicação de cor personalizada do LED MagSafe."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative ou desative a indicação de cor personalizada do LED MagSafe."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить или отключить пользовательскую цветовую индикацию светодиода MagSafe."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povoľte alebo zakážte vlastnú farebnú signalizáciu LED MagSafe."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogočite ali onemogočite prikaz barve po meri za lučko LED MagSafe."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel MagSafe LED renk göstergesini etkinleştirin veya devre dışı bırakın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật hoặc tắt chỉ báo màu LED MagSafe tùy chỉnh."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用或停用自訂 MagSafe LED 顏色指示。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva la indicación de color personalizada del LED MagSafe."
           }
         }
       }
@@ -43215,6 +43983,102 @@
             "state": "translated",
             "value": "Stasis 支持自定义 URL 方案（**stasis://**）和命令行自动化。这是一套百分之百可靠、通用的自动化系统，可用于 Apple 快捷指令、Raycast、Alfred 和终端脚本，无需 Apple 开发者账户。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis unterstützt benutzerdefinierte URL-Schemata (**stasis://**) und die Automatisierung über die Befehlszeile. Dieses vollständig zuverlässige, universelle Automatisierungssystem funktioniert mit Apple Kurzbefehlen, Raycast, Alfred und Terminal-Skripten – ganz ohne Apple-Entwickleraccount."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis admite esquemas de URL personalizados (**stasis://**) y automatización mediante la línea de comandos. Es un sistema de automatización universal y totalmente fiable que funciona con Atajos de Apple, Raycast, Alfred y scripts de Terminal, sin necesidad de una cuenta de Apple Developer."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis prend en charge les schémas d’URL personnalisés (**stasis://**) et l’automatisation en ligne de commande. Ce système d’automatisation universel et entièrement fiable fonctionne avec Raccourcis d’Apple, Raycast, Alfred et les scripts de Terminal, sans compte Apple Developer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis supporta schemi URL personalizzati (**stasis://**) e l’automazione da riga di comando. È un sistema di automazione universale e completamente affidabile che funziona con Comandi Rapidi di Apple, Raycast, Alfred e gli script di Terminale, senza richiedere un account Apple Developer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "StasisはカスタムURLスキーム（**stasis://**）とコマンドライン自動化に対応しています。Appleのショートカット、Raycast、Alfred、ターミナルスクリプトで利用できる、完全に信頼性の高い汎用自動化システムです。Apple Developerアカウントは必要ありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis는 사용자 지정 URL 스킴(**stasis://**)과 명령줄 자동화를 지원합니다. Apple 단축어, Raycast, Alfred 및 터미널 스크립트에서 Apple Developer 계정 없이 작동하는 완전히 신뢰할 수 있는 범용 자동화 시스템입니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis ondersteunt aangepaste URL-schema’s (**stasis://**) en automatisering via de opdrachtregel. Dit volledig betrouwbare, universele automatiseringssysteem werkt met Apple Opdrachten, Raycast, Alfred en Terminal-scripts, zonder Apple Developer-account."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Stasis oferece esquemas de URL personalizados (**stasis://**) e automação por linha de comando. É um sistema de automação universal e totalmente confiável que funciona com Atalhos da Apple, Raycast, Alfred e scripts do Terminal, sem precisar de uma conta do Apple Developer."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Stasis suporta esquemas de URL personalizados (**stasis://**) e automatização através da linha de comandos. É um sistema de automatização universal e totalmente fiável que funciona com Atalhos da Apple, Raycast, Alfred e scripts do Terminal, sem necessitar de uma conta Apple Developer."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis поддерживает пользовательские схемы URL (**stasis://**) и автоматизацию через командную строку. Это полностью надёжная универсальная система автоматизации, которая работает с приложением «Команды» Apple, Raycast, Alfred и скриптами Терминала без учётной записи Apple Developer."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis podporuje vlastné schémy URL (**stasis://**) a automatizáciu cez príkazový riadok. Tento úplne spoľahlivý univerzálny automatizačný systém funguje so Skratkami Apple, Raycastom, Alfredom a skriptmi Terminálu bez účtu Apple Developer."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis podpira sheme URL po meri (**stasis://**) in avtomatizacijo prek ukazne vrstice. Ta popolnoma zanesljiv univerzalni sistem avtomatizacije deluje z Applovimi Bližnjicami, Raycastom, Alfredom in skripti Terminala brez računa Apple Developer."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis, özel URL şemalarını (**stasis://**) ve komut satırı otomasyonunu destekler. Apple Kestirmeler, Raycast, Alfred ve Terminal betikleriyle Apple Developer hesabı gerektirmeden çalışan, tamamen güvenilir ve evrensel bir otomasyon sistemidir."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis hỗ trợ lược đồ URL tùy chỉnh (**stasis://**) và tự động hóa bằng dòng lệnh. Đây là hệ thống tự động hóa phổ quát, hoàn toàn đáng tin cậy, hoạt động với Phím tắt của Apple, Raycast, Alfred và tập lệnh Terminal mà không cần tài khoản Apple Developer."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis 支援自訂 URL 方案（**stasis://**）和命令列自動化。這是一套百分之百可靠、通用的自動化系統，可用於 Apple 捷徑、Raycast、Alfred 和終端機指令碼，無需 Apple 開發者帳號。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stasis admite esquemas de URL personalizados (**stasis://**) y automatización mediante la línea de comandos. Es un sistema de automatización universal y totalmente fiable que funciona con Atajos de Apple, Raycast, Alfred y scripts de Terminal, sin necesidad de una cuenta de Apple Developer."
+          }
         }
       }
     },
@@ -43225,6 +44089,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "如何在 Apple 的“快捷指令”App 中使用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendung in Apples Kurzbefehle-App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cómo usar la app Atajos de Apple"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation dans l’app Raccourcis d’Apple"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Come usare l’app Comandi Rapidi di Apple"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppleのショートカットAppでの使い方"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 단축어 앱에서 사용하는 방법"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gebruik in de Opdrachten-app van Apple"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Como usar no app Atalhos da Apple"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Como utilizar na app Atalhos da Apple"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование в приложении «Команды» Apple"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Používanie v aplikácii Skratky od Apple"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uporaba v Applovi aplikaciji Bližnjice"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple’ın Kestirmeler Uygulamasında Kullanım"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cách sử dụng trong ứng dụng Phím tắt của Apple"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如何在 Apple 的「捷徑」App 中使用"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cómo usar la app Atajos de Apple"
           }
         }
       }
@@ -43237,6 +44197,102 @@
             "state": "translated",
             "value": "CLI 与终端用法"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI- & Terminal-Nutzung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso de CLI y Terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation de la CLI et du Terminal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso di CLI e Terminale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLIとターミナルの使用方法"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 및 터미널 사용법"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI- en Terminal-gebruik"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso da CLI e do Terminal"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilização da CLI e do Terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование CLI и Терминала"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Používanie CLI a Terminálu"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uporaba CLI in Terminala"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI ve Terminal Kullanımı"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sử dụng CLI và Terminal"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 與終端機用法"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso de CLI y Terminal"
+          }
         }
       }
     },
@@ -43247,6 +44303,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "你可以在终端、Shell 脚本、Raycast 或 Alfred 中使用 `open` 命令运行任意 Stasis 命令："
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du kannst jeden Stasis-Befehl im Terminal, in Shell-Skripten, Raycast oder Alfred mit dem Befehl `open` ausführen:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puedes ejecutar cualquier comando de Stasis desde Terminal, scripts de shell, Raycast o Alfred mediante el comando `open`:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous pouvez exécuter n’importe quelle commande Stasis depuis le Terminal, des scripts shell, Raycast ou Alfred à l’aide de la commande `open` :"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puoi eseguire qualsiasi comando Stasis da Terminale, script di shell, Raycast o Alfred usando il comando `open`:"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル、シェルスクリプト、Raycast、Alfredから、`open`コマンドを使って任意のStasisコマンドを実行できます："
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널, 셸 스크립트, Raycast 또는 Alfred에서 `open` 명령으로 모든 Stasis 명령을 실행할 수 있습니다:"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je kunt elke Stasis-opdracht uitvoeren vanuit Terminal, shellscripts, Raycast of Alfred met de opdracht `open`:"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você pode executar qualquer comando do Stasis pelo Terminal, por scripts de shell, Raycast ou Alfred usando o comando `open`:"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pode executar qualquer comando do Stasis no Terminal, em scripts de shell, no Raycast ou no Alfred utilizando o comando `open`:"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Любую команду Stasis можно выполнить из Терминала, скриптов оболочки, Raycast или Alfred с помощью команды `open`:"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ľubovoľný príkaz Stasis môžete spustiť z Terminálu, shellových skriptov, Raycastu alebo Alfredu pomocou príkazu `open`:"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kateri koli ukaz Stasis lahko zaženete iz Terminala, lupinskih skriptov, Raycasta ali Alfreda z ukazom `open`:"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herhangi bir Stasis komutunu Terminal, kabuk betikleri, Raycast veya Alfred’dan `open` komutuyla çalıştırabilirsiniz:"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có thể chạy bất kỳ lệnh Stasis nào từ Terminal, tập lệnh shell, Raycast hoặc Alfred bằng lệnh `open`:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你可以在終端機、Shell 指令碼、Raycast 或 Alfred 中使用 `open` 指令執行任意 Stasis 指令："
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puedes ejecutar cualquier comando de Stasis desde Terminal, scripts de shell, Raycast o Alfred mediante el comando `open`:"
           }
         }
       }
@@ -43259,6 +44411,102 @@
             "state": "translated",
             "value": "URL 方案参考"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL-Schema-Referenz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referencia del esquema de URL"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Référence du schéma d’URL"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riferimento dello schema URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLスキーム一覧"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 스킴 참조"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overzicht van URL-schema’s"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referência do esquema de URL"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referência do esquema de URL"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Справочник схемы URL"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prehľad schémy URL"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pregled sheme URL"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL Şeması Referansı"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tham chiếu lược đồ URL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 方案參考"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referencia del esquema de URL"
+          }
         }
       }
     },
@@ -43269,6 +44517,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 Mac 上打开 Apple 的**快捷指令** App。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne Apples App **Kurzbefehle** auf deinem Mac."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre la app **Atajos** de Apple en tu Mac."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez l’app **Raccourcis** d’Apple sur votre Mac."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri l’app **Comandi Rapidi** di Apple sul Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacでAppleの**ショートカット**Appを開きます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac에서 Apple의 **단축어** 앱을 엽니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open de Apple-app **Opdrachten** op je Mac."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o app **Atalhos** da Apple no Mac."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra a app **Atalhos** da Apple no Mac."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте приложение Apple **Команды** на Mac."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvorte na Macu aplikáciu Apple **Skratky**."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "V Macu odprite Applovo aplikacijo **Bližnjice**."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac’inizde Apple’ın **Kestirmeler** uygulamasını açın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở ứng dụng **Phím tắt** của Apple trên máy Mac."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 上開啟 Apple 的**捷徑** App。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre la app **Atajos** de Apple en tu Mac."
           }
         }
       }
@@ -43281,6 +44625,102 @@
             "state": "translated",
             "value": "新建一个快捷指令，并添加**打开 URL**操作。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstelle einen neuen Kurzbefehl und füge die Aktion **URL öffnen** hinzu."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea un nuevo atajo y añade la acción **Abrir URL**."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez un nouveau raccourci et ajoutez l’action **Ouvrir les URL**."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea un nuovo comando rapido e aggiungi l’azione **Apri URL**."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいショートカットを作成し、**URLを開く**アクションを追加します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 단축어를 만들고 **URL 열기** 동작을 추가합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maak een nieuwe opdracht aan en voeg de taak **Open URL** toe."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie um novo atalho e adicione a ação **Abrir URLs**."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie um novo atalho e adicione a ação **Abrir URL**."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создайте новую команду и добавьте действие **Открыть URL**."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vytvorte novú skratku a pridajte akciu **Otvoriť URL**."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustvarite novo bližnjico in dodajte dejanje **Odpri URL**."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni bir kestirme oluşturun ve **URL’yi Aç** eylemini ekleyin."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo một phím tắt mới và thêm tác vụ **Mở URL**."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增捷徑，並加入**打開 URL**動作。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea un nuevo atajo y añade la acción **Abrir URL**."
+          }
         }
       }
     },
@@ -43291,6 +44731,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "粘贴下方参考列表中的任意 Stasis URL（例如 `stasis://charge-limit?value=80`）。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füge eine beliebige Stasis-URL aus der Referenzliste unten ein (z. B. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega cualquier URL de Stasis de la lista de referencia siguiente (p. ej., `stasis://charge-limit?value=80`)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collez une URL Stasis de la liste de référence ci-dessous (par ex. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incolla un URL Stasis dall’elenco di riferimento seguente (ad es. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下の一覧からStasis URLを貼り付けます（例：`stasis://charge-limit?value=80`）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아래 참조 목록에서 Stasis URL을 붙여넣습니다(예: `stasis://charge-limit?value=80`)."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plak een Stasis-URL uit de onderstaande lijst (bijv. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cole uma URL do Stasis da lista de referência abaixo (por exemplo, `stasis://charge-limit?value=80`)."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cole um URL do Stasis da lista de referência abaixo (por exemplo, `stasis://charge-limit?value=80`)."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставьте любой URL Stasis из списка ниже (например, `stasis://charge-limit?value=80`)."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vložte ľubovoľnú URL Stasis zo zoznamu nižšie (napr. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prilepite kateri koli URL Stasis s spodnjega seznama (npr. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aşağıdaki referans listesinden bir Stasis URL’si yapıştırın (ör. `stasis://charge-limit?value=80`)."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dán một URL Stasis từ danh sách tham chiếu bên dưới (ví dụ: `stasis://charge-limit?value=80`)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "貼上下方參考列表中的任意 Stasis URL（例如 `stasis://charge-limit?value=80`）。"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega cualquier URL de Stasis de la lista de referencia siguiente (p. ej., `stasis://charge-limit?value=80`)."
           }
         }
       }
@@ -43303,6 +44839,102 @@
             "state": "translated",
             "value": "可从菜单栏、键盘快捷键、Dock 或 Siri 运行你的快捷指令！"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe deinen Kurzbefehl über die Menüleiste, einen Tastaturkurzbefehl, das Dock oder Siri aus!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta tu atajo desde la barra de menús, un atajo de teclado, el Dock o Siri."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécutez votre raccourci depuis la barre des menus, un raccourci clavier, le Dock ou Siri !"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esegui il comando rapido dalla barra dei menu, da un’abbreviazione da tastiera, dal Dock o con Siri."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバー、キーボードショートカット、Dock、またはSiriからショートカットを実行します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대, 키보드 단축키, Dock 또는 Siri에서 단축어를 실행하세요!"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voer je opdracht uit via de menubalk, een toetscombinatie, het Dock of Siri."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Execute o atalho pela barra de menus, por um atalho de teclado, pelo Dock ou pela Siri."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Execute o atalho a partir da barra de menus, de um atalho de teclado, da Dock ou através da Siri."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустите команду из строки меню, сочетанием клавиш, из Dock или с помощью Siri."
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spustite skratku z panela ponúk, klávesovou skratkou, z Docku alebo pomocou Siri."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zaženite bližnjico iz menijske vrstice, z bližnjico na tipkovnici, iz Docka ali s Siri."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kestirmenizi Menü Çubuğu, klavye kestirmesi, Dock veya Siri’den çalıştırın!"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạy phím tắt từ thanh menu, phím tắt bàn phím, Dock hoặc Siri!"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可從選單列、鍵盤快速鍵、Dock 或 Siri 執行你的捷徑！"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta tu atajo desde la barra de menús, un atajo de teclado, el Dock o Siri."
+          }
         }
       }
     },
@@ -43313,6 +44945,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "已复制"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copié"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사됨"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gekopieerd"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопировано"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skopírované"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopirano"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopyalandı"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã sao chép"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已複製"
+          }
+        },
+        "es-US": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado"
           }
         }
       }

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1620,7 +1620,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "アダプター"
           }
         },
         "zh-Hans": {
@@ -1632,7 +1632,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "電源轉接器"
           }
         },
         "ru": {
@@ -1668,13 +1668,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Bộ đổi nguồn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "어댑터"
           }
         },
         "fr": {
@@ -1726,7 +1726,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "アダプタの電力メトリクス"
           }
         },
         "zh-Hans": {
@@ -1738,7 +1738,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "電源轉接器功率指標"
           }
         },
         "ru": {
@@ -1774,13 +1774,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "Chỉ số công suất bộ đổi nguồn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia do adaptador"
+            "value": "어댑터 전력 측정항목"
           }
         },
         "fr": {
@@ -1832,7 +1832,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "このデバイスではアダプター制御はサポートされていません。"
           }
         },
         "zh-Hans": {
@@ -1844,7 +1844,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "此裝置不支援電源轉接器控制。"
           }
         },
         "ru": {
@@ -1880,13 +1880,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "Thiết bị này không hỗ trợ điều khiển bộ đổi nguồn."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do adaptador não é suportado neste dispositivo."
+            "value": "이 장치에서는 어댑터 제어가 지원되지 않습니다."
           }
         },
         "fr": {
@@ -2044,7 +2044,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "すべてのディスプレイ"
           }
         },
         "zh-Hans": {
@@ -2056,7 +2056,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "所有顯示器"
           }
         },
         "ru": {
@@ -2092,13 +2092,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "Tất cả màn hình"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos os ecrãs"
+            "value": "모든 디스플레이"
           }
         },
         "fr": {
@@ -2377,13 +2377,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "すべての設定がデフォルトに正常に復元されました。アプリが再起動されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "모든 기본 설정이 기본값으로 성공적으로 복원되었습니다. 이제 앱이 다시 시작됩니다."
           }
         },
         "nl": {
@@ -2431,7 +2431,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "Tất cả các tùy chọn đã được khôi phục thành công về mặc định. Ứng dụng bây giờ sẽ khởi động lại."
           }
         },
         "zh-Hans": {
@@ -2443,7 +2443,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as definições foram repostas para os valores predefinidos. A aplicação vai ser reiniciada."
+            "value": "所有首選項已成功恢復為預設值。該應用程式現在將重新啟動。"
           }
         }
       }
@@ -2790,7 +2790,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "システム設定→ログイン項目でStasisを承認して続行します。"
           }
         },
         "zh-Hans": {
@@ -2802,7 +2802,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "請在「系統設定」→「登入項目」中核准 Stasis，以繼續。"
           }
         },
         "ru": {
@@ -2838,13 +2838,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "Phê duyệt Stasis trong Cài đặt hệ thống → Mục đăng nhập để tiếp tục."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aprove o Stasis em Definições do Sistema → Itens de Início para continuar."
+            "value": "계속하려면 시스템 설정 → 로그인 항목에서 Stasis를 승인하세요."
           }
         },
         "fr": {
@@ -3003,7 +3003,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "自動ダウンロード"
           }
         },
         "zh-Hans": {
@@ -3015,7 +3015,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "自動下載"
           }
         },
         "ru": {
@@ -3051,13 +3051,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "Tự động tải xuống"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transferir automaticamente"
+            "value": "자동 다운로드"
           }
         },
         "fr": {
@@ -3109,7 +3109,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "自動放電"
           }
         },
         "zh-Hans": {
@@ -3121,7 +3121,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "自動放電"
           }
         },
         "ru": {
@@ -3157,13 +3157,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "Xả pin tự động"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga automática"
+            "value": "자동 방전"
           }
         },
         "fr": {
@@ -3215,7 +3215,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "アップデートを自動的にチェックする"
           }
         },
         "zh-Hans": {
@@ -3227,7 +3227,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "自動檢查更新"
           }
         },
         "ru": {
@@ -3263,13 +3263,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "Tự động kiểm tra cập nhật"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações automaticamente"
+            "value": "자동으로 업데이트 확인"
           }
         },
         "fr": {
@@ -3321,7 +3321,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "バッテリーが充電制限に対するしきい値を下回ると、自動的に充電を再開します。"
           }
         },
         "zh-Hans": {
@@ -3333,7 +3333,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "當電池電量低於相對於充電限制的閾值時，自動恢復充電。"
           }
         },
         "ru": {
@@ -3369,13 +3369,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "Tự động tiếp tục sạc khi pin giảm xuống dưới ngưỡng tương ứng với giới hạn sạc của bạn."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Retomar o carregamento automaticamente quando a bateria descer abaixo do limiar em relação ao seu limite de carga."
+            "value": "배터리가 충전 한도에 비해 임계값 아래로 떨어지면 자동으로 충전을 재개합니다."
           }
         },
         "fr": {
@@ -3534,7 +3534,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "バックグラウンドヘルパーが切断されました"
           }
         },
         "zh-Hans": {
@@ -3546,7 +3546,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "後台輔助程式已中斷連線"
           }
         },
         "ru": {
@@ -3582,13 +3582,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "Trình trợ giúp nền đã ngắt kết nối"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar em segundo plano desligado"
+            "value": "백그라운드 도우미 연결 끊김"
           }
         },
         "fr": {
@@ -3852,7 +3852,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "バッテリーと電源アダプター"
           }
         },
         "zh-Hans": {
@@ -3864,7 +3864,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "電池與電源轉接器"
           }
         },
         "ru": {
@@ -3900,13 +3900,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "Pin và bộ đổi nguồn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente"
+            "value": "배터리 및 전원 어댑터"
           }
         },
         "fr": {
@@ -3958,7 +3958,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "バッテリーと電源アダプター (%@ W)"
           }
         },
         "zh-Hans": {
@@ -3970,7 +3970,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "電池和電源適配器 (%@ W)"
           }
         },
         "ru": {
@@ -4006,13 +4006,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "Pin & Bộ đổi nguồn (%@ W)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%@ W)"
+            "value": "배터리 및 전원 어댑터(%@ W)"
           }
         },
         "fr": {
@@ -4064,7 +4064,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "バッテリーと電源アダプター (%d W)"
           }
         },
         "zh-Hans": {
@@ -4076,7 +4076,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "電池和電源適配器 (%d W)"
           }
         },
         "ru": {
@@ -4112,13 +4112,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "Pin & Bộ đổi nguồn (%d W)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%d W)"
+            "value": "배터리 및 전원 어댑터(%d W)"
           }
         },
         "fr": {
@@ -4170,7 +4170,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "バッテリーと電源アダプター (%lld W)"
           }
         },
         "zh-Hans": {
@@ -4182,7 +4182,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "電池和電源適配器 (%lld W)"
           }
         },
         "ru": {
@@ -4218,13 +4218,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "Pin & Bộ đổi nguồn (%lld W)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bateria e adaptador de corrente (%lld W)"
+            "value": "배터리 및 전원 어댑터(%lld W)"
           }
         },
         "fr": {
@@ -4276,7 +4276,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "バッテリーの校正"
           }
         },
         "zh-Hans": {
@@ -4288,7 +4288,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "電池校準"
           }
         },
         "ru": {
@@ -4324,13 +4324,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "Hiệu chỉnh pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria"
+            "value": "배터리 보정"
           }
         },
         "fr": {
@@ -4382,7 +4382,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "バッテリー校正期限"
           }
         },
         "zh-Hans": {
@@ -4394,7 +4394,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "電池校準到期"
           }
         },
         "ru": {
@@ -4430,13 +4430,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "Đến hạn hiệu chỉnh pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Calibração da bateria programada"
+            "value": "배터리 보정 예정"
           }
         },
         "fr": {
@@ -4594,7 +4594,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "バッテリーモード"
           }
         },
         "zh-Hans": {
@@ -4606,7 +4606,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "電池模式"
           }
         },
         "ru": {
@@ -4642,13 +4642,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Chế độ pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "배터리 모드"
           }
         },
         "fr": {
@@ -4700,7 +4700,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "バッテリーのみ"
           }
         },
         "zh-Hans": {
@@ -4712,7 +4712,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "僅電池"
           }
         },
         "ru": {
@@ -4748,13 +4748,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "Chỉ dùng pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas bateria"
+            "value": "배터리만"
           }
         },
         "fr": {
@@ -4806,7 +4806,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "バッテリー電力のメトリクス"
           }
         },
         "zh-Hans": {
@@ -4818,7 +4818,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "電池電量指標"
           }
         },
         "ru": {
@@ -4854,13 +4854,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "Số liệu năng lượng pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Métricas de energia da bateria"
+            "value": "배터리 전력 측정항목"
           }
         },
         "fr": {
@@ -4912,7 +4912,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "バッテリー測定値"
           }
         },
         "zh-Hans": {
@@ -4924,7 +4924,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "電池讀數"
           }
         },
         "ru": {
@@ -4960,13 +4960,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "Chỉ số pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Leitura da bateria"
+            "value": "배터리 측정값"
           }
         },
         "fr": {
@@ -5018,7 +5018,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "バッテリー温度"
           }
         },
         "zh-Hans": {
@@ -5030,7 +5030,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "電池溫度"
           }
         },
         "ru": {
@@ -5066,13 +5066,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "Nhiệt độ pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura da bateria"
+            "value": "배터리 온도"
           }
         },
         "fr": {
@@ -5124,7 +5124,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "MacBookのバッテリーと充電の制御。"
           }
         },
         "zh-Hans": {
@@ -5136,7 +5136,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "MacBook 的電池和充電控制。"
           }
         },
         "ru": {
@@ -5172,13 +5172,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "Kiểm soát pin và sạc cho MacBook."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo de bateria e carregamento para MacBook."
+            "value": "MacBook의 배터리 및 충전 제어."
           }
         },
         "fr": {
@@ -5444,7 +5444,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "このデバイスではバッテリーの校正はサポートされていません。"
           }
         },
         "zh-Hans": {
@@ -5456,7 +5456,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "本設備不支援電池校準。"
           }
         },
         "ru": {
@@ -5492,13 +5492,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "Hiệu chỉnh pin không được hỗ trợ trên thiết bị này."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibração da bateria não é suportada neste dispositivo."
+            "value": "이 장치에서는 배터리 보정이 지원되지 않습니다."
           }
         },
         "fr": {
@@ -5550,7 +5550,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "バッテリーモード"
           }
         },
         "zh-Hans": {
@@ -5562,7 +5562,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "電池模式"
           }
         },
         "ru": {
@@ -5598,13 +5598,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "Chế độ pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo da bateria"
+            "value": "배터리 모드"
           }
         },
         "fr": {
@@ -5762,7 +5762,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "オレンジ色で速く点滅"
           }
         },
         "zh-Hans": {
@@ -5774,7 +5774,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "橘色快速閃爍"
           }
         },
         "ru": {
@@ -5810,13 +5810,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "Màu cam nhấp nháy nhanh"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente rápido"
+            "value": "주황색으로 빠르게 깜박임"
           }
         },
         "fr": {
@@ -5868,7 +5868,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "オレンジ色でゆっくり点滅"
           }
         },
         "zh-Hans": {
@@ -5880,7 +5880,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "橘色緩慢閃爍"
           }
         },
         "ru": {
@@ -5916,13 +5916,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "Màu cam nhấp nháy chậm"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja intermitente lento"
+            "value": "주황색으로 느리게 깜박임"
           }
         },
         "fr": {
@@ -5974,7 +5974,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "実用的なバッテリーの状態と充電ワークフローに重点を置いて構築されています。"
           }
         },
         "zh-Hans": {
@@ -5986,7 +5986,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "專注於實際電池健康狀況和充電工作流程。"
           }
         },
         "ru": {
@@ -6022,13 +6022,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "Được xây dựng tập trung vào tình trạng thực tế của pin và quy trình sạc."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Concebido com foco em fluxos de trabalho práticos de carregamento e saúde da bateria."
+            "value": "실용적인 배터리 상태 및 충전 워크플로에 중점을 두고 제작되었습니다."
           }
         },
         "fr": {
@@ -6080,7 +6080,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "計算中..."
           }
         },
         "zh-Hans": {
@@ -6092,7 +6092,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "正在計算..."
           }
         },
         "ru": {
@@ -6128,13 +6128,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "Đang tính..."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calcular..."
+            "value": "계산 중..."
           }
         },
         "fr": {
@@ -6294,7 +6294,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "校正中（%@に充電）"
           }
         },
         "zh-Hans": {
@@ -6306,7 +6306,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "校準（給%@充電）"
           }
         },
         "ru": {
@@ -6342,13 +6342,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "Đang hiệu chỉnh (Sạc tới %@)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar até %@)"
+            "value": "교정 중(%@로 충전 중)"
           }
         },
         "fr": {
@@ -6400,7 +6400,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "校正中（充電中）"
           }
         },
         "zh-Hans": {
@@ -6412,7 +6412,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "校準（充電）"
           }
         },
         "ru": {
@@ -6448,13 +6448,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "Hiệu chỉnh (Sạc lên)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Carregar)"
+            "value": "교정 중(충전 중)"
           }
         },
         "fr": {
@@ -6507,7 +6507,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "校正中（%@まで放電）"
           }
         },
         "zh-Hans": {
@@ -6519,7 +6519,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "校準（放電到%@）"
           }
         },
         "ru": {
@@ -6555,13 +6555,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "Hiệu chỉnh (Xả tới %@)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Descarregar até %@)"
+            "value": "교정 중(%@로 방전)"
           }
         },
         "fr": {
@@ -6613,7 +6613,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "校正（放電）中"
           }
         },
         "zh-Hans": {
@@ -6625,7 +6625,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "校準（放電）"
           }
         },
         "ru": {
@@ -6661,13 +6661,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "Hiệu chuẩn (Xả)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (A descarregar)"
+            "value": "교정(방전)"
           }
         },
         "fr": {
@@ -6719,7 +6719,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "キャリブレーション中 (一時停止 - プラグイン)"
           }
         },
         "zh-Hans": {
@@ -6731,7 +6731,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "校準（暫停 - 插入）"
           }
         },
         "ru": {
@@ -6767,13 +6767,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "Đang hiệu chỉnh (Tạm dừng - Cắm vào)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em pausa - Ligar carregador)"
+            "value": "교정 중(일시중지됨 - 플러그인)"
           }
         },
         "fr": {
@@ -6826,7 +6826,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "校正中 (%@ で休止中)"
           }
         },
         "zh-Hans": {
@@ -6838,7 +6838,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "校準（靜止在 %@）"
           }
         },
         "ru": {
@@ -6874,13 +6874,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "Hiệu chỉnh (Nghỉ ở %@)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso a %@)"
+            "value": "교정 중(%@에 위치)"
           }
         },
         "fr": {
@@ -6932,7 +6932,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "校正中（休止中）"
           }
         },
         "zh-Hans": {
@@ -6944,7 +6944,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "校準（休息）"
           }
         },
         "ru": {
@@ -6980,13 +6980,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "Hiệu chỉnh (Nghỉ)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A calibrar (Em repouso)"
+            "value": "교정 중(휴식)"
           }
         },
         "fr": {
@@ -7465,7 +7465,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "キャリブレーションのキャンセル"
           }
         },
         "zh-Hans": {
@@ -7477,7 +7477,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "取消校準"
           }
         },
         "ru": {
@@ -7513,13 +7513,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "Hủy hiệu chuẩn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelar calibração"
+            "value": "교정 취소"
           }
         },
         "fr": {
@@ -7892,7 +7892,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "表示言語を変更します..."
           }
         },
         "zh-Hans": {
@@ -7904,7 +7904,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "更改顯示語言..."
           }
         },
         "ru": {
@@ -7940,13 +7940,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "Thay đổi ngôn ngữ hiển thị..."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alterar idioma de exibição..."
+            "value": "표시 언어 변경..."
           }
         },
         "fr": {
@@ -8105,7 +8105,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "充電上限の一時解除"
           }
         },
         "zh-Hans": {
@@ -8117,7 +8117,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "暫時覆寫充電上限"
           }
         },
         "ru": {
@@ -8153,13 +8153,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "Ghi đè giới hạn sạc"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sobreposição do limite de carga"
+            "value": "충전 제한 무시"
           }
         },
         "fr": {
@@ -8211,7 +8211,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "充電管理"
           }
         },
         "zh-Hans": {
@@ -8223,7 +8223,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "充電管理"
           }
         },
         "ru": {
@@ -8259,13 +8259,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "Quản lý sạc"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestão de carga"
+            "value": "충전 관리"
           }
         },
         "fr": {
@@ -8851,7 +8851,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "このデバイスでは充電管理はサポートされていません。"
           }
         },
         "zh-Hans": {
@@ -8863,7 +8863,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "此設備不支援充電管理。"
           }
         },
         "ru": {
@@ -8899,13 +8899,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "Thiết bị này không hỗ trợ quản lý sạc."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A gestão de carga não é suportada neste dispositivo."
+            "value": "이 기기에서는 충전 관리가 지원되지 않습니다."
           }
         },
         "fr": {
@@ -9170,7 +9170,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "このデバイスでは充電制御はサポートされていません。"
           }
         },
         "zh-Hans": {
@@ -9182,7 +9182,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "該設備不支援充電控制。"
           }
         },
         "ru": {
@@ -9218,13 +9218,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "Kiểm soát sạc không được hỗ trợ trên thiết bị này."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo de carregamento não é suportado neste dispositivo."
+            "value": "이 장치에서는 충전 제어가 지원되지 않습니다."
           }
         },
         "fr": {
@@ -9276,7 +9276,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "充電が再開されます"
           }
         },
         "zh-Hans": {
@@ -9288,7 +9288,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "充電恢復時間為"
           }
         },
         "ru": {
@@ -9324,13 +9324,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "Quá trình sạc tiếp tục lúc"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregamento retoma a"
+            "value": "충전 재개 시간:"
           }
         },
         "fr": {
@@ -9382,7 +9382,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "充電ステータスが変更されました"
           }
         },
         "zh-Hans": {
@@ -9394,7 +9394,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "充電狀態改變"
           }
         },
         "ru": {
@@ -9430,13 +9430,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "Trạng thái sạc đã thay đổi"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado de carregamento alterado"
+            "value": "충전 상태가 변경됨"
           }
         },
         "fr": {
@@ -9489,7 +9489,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "%@ への充電 (オーバーライド)"
           }
         },
         "zh-Hans": {
@@ -9501,7 +9501,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "向 %@ 充電（覆蓋）"
           }
         },
         "ru": {
@@ -9537,13 +9537,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "Đang sạc tới %@ (Ghi đè)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@ (Sobreposição)"
+            "value": "%@로 충전 중(재정의)"
           }
         },
         "fr": {
@@ -9596,7 +9596,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "%@ に充電中..."
           }
         },
         "zh-Hans": {
@@ -9608,7 +9608,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "正在為 %@ 充電..."
           }
         },
         "ru": {
@@ -9644,13 +9644,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "Đang sạc tới %@..."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até %@..."
+            "value": "%@로 충전 중..."
           }
         },
         "fr": {
@@ -9715,13 +9715,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "上限まで充電中"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "한도까지 충전 중"
           }
         },
         "nl": {
@@ -9769,7 +9769,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "Đang sạc đến giới hạn"
           }
         },
         "zh-Hans": {
@@ -9781,7 +9781,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A carregar até ao limite"
+            "value": "正在充電至上限"
           }
         }
       }
@@ -9809,7 +9809,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "もう一度確認してください"
           }
         },
         "zh-Hans": {
@@ -9821,7 +9821,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "再次檢查"
           }
         },
         "ru": {
@@ -9857,13 +9857,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "Kiểm tra lại"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verificar novamente"
+            "value": "다시 확인하세요"
           }
         },
         "fr": {
@@ -10129,7 +10129,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "今すぐアップデートをチェックしてください"
           }
         },
         "zh-Hans": {
@@ -10141,7 +10141,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "立即檢查更新"
           }
         },
         "ru": {
@@ -10177,13 +10177,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "Kiểm tra cập nhật ngay bây giờ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Procurar atualizações agora"
+            "value": "지금 업데이트를 확인하세요"
           }
         },
         "fr": {
@@ -10235,7 +10235,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "チェック頻度"
           }
         },
         "zh-Hans": {
@@ -10247,7 +10247,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "檢查頻率"
           }
         },
         "ru": {
@@ -10283,13 +10283,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "Kiểm tra tần suất"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Frequência de verificação"
+            "value": "빈도 확인"
           }
         },
         "fr": {
@@ -10555,7 +10555,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "コミュニティ"
           }
         },
         "zh-Hans": {
@@ -10567,7 +10567,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "社群"
           }
         },
         "ru": {
@@ -10603,13 +10603,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "cộng đồng"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunidade"
+            "value": "커뮤니티"
           }
         },
         "fr": {
@@ -10768,7 +10768,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Stasis が通知を送信するタイミングを制御します。"
           }
         },
         "zh-Hans": {
@@ -10780,7 +10780,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "控制 Stasis 何時向您發送通知。"
           }
         },
         "ru": {
@@ -10816,13 +10816,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Kiểm soát thời điểm Stasis gửi thông báo cho bạn."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controle quando o Stasis envia notificações."
+            "value": "Stasis가 알림을 보내는 시점을 제어합니다."
           }
         },
         "fr": {
@@ -11087,7 +11087,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "サイクル数"
           }
         },
         "zh-Hans": {
@@ -11099,7 +11099,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "週期計數"
           }
         },
         "ru": {
@@ -11135,13 +11135,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "Số chu kỳ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contagem de ciclos"
+            "value": "사이클 수"
           }
         },
         "fr": {
@@ -11193,7 +11193,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "デーモン エラー - 設定が同期されていません"
           }
         },
         "zh-Hans": {
@@ -11205,7 +11205,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "守護程序錯誤 - 設定未同步"
           }
         },
         "ru": {
@@ -11241,13 +11241,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "Lỗi Daemon - Cài đặt không được đồng bộ hóa"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erro do Daemon - Definições não sincronizadas"
+            "value": "데몬 오류 - 설정이 동기화되지 않음"
           }
         },
         "fr": {
@@ -11299,7 +11299,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "毎日"
           }
         },
         "zh-Hans": {
@@ -11311,7 +11311,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "每日"
           }
         },
         "ru": {
@@ -11347,13 +11347,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "hàng ngày"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diariamente"
+            "value": "매일"
           }
         },
         "fr": {
@@ -11936,7 +11936,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "すべての通知を無効にする"
           }
         },
         "zh-Hans": {
@@ -11948,7 +11948,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "停用所有通知"
           }
         },
         "ru": {
@@ -11984,13 +11984,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "Tắt tất cả thông báo"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar todas as notificações"
+            "value": "모든 알림 비활성화"
           }
         },
         "fr": {
@@ -12256,7 +12256,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "充電制限までスリープを無効にする"
           }
         },
         "zh-Hans": {
@@ -12268,7 +12268,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "禁用睡眠至電量達到上限"
           }
         },
         "ru": {
@@ -12304,13 +12304,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "Tắt chế độ ngủ cho đến khi đạt giới hạn sạc"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar suspensão até ao limite de carga"
+            "value": "충전 한도까지 절전 모드 비활성화"
           }
         },
         "fr": {
@@ -12362,7 +12362,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "放電"
           }
         },
         "zh-Hans": {
@@ -12374,7 +12374,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "放電"
           }
         },
         "ru": {
@@ -12410,13 +12410,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "Xả pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar"
+            "value": "방전"
           }
         },
         "fr": {
@@ -12575,7 +12575,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "目標レベルを超えて接続されている場合は、充電限界までバッテリーを放電してください。"
           }
         },
         "zh-Hans": {
@@ -12587,7 +12587,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "當插入電池時，將電池放電至高於目標電量的充電限制。"
           }
         },
         "ru": {
@@ -12623,13 +12623,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "Xả pin đến giới hạn sạc của bạn khi cắm điện trên mức mục tiêu."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarregar a bateria até ao limite de carga quando ligada à corrente acima do nível pretendido."
+            "value": "목표 수준 이상으로 연결되면 배터리를 충전 한도까지 방전하십시오."
           }
         },
         "fr": {
@@ -12789,7 +12789,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "%@ まで放電中..."
           }
         },
         "zh-Hans": {
@@ -12801,7 +12801,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "正在放電至 %@..."
           }
         },
         "ru": {
@@ -12837,13 +12837,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "Đang xả pin đến %@..."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até %@..."
+            "value": "%@까지 방전 중..."
           }
         },
         "fr": {
@@ -12895,7 +12895,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "閉じる"
           }
         },
         "zh-Hans": {
@@ -12907,7 +12907,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "關閉"
           }
         },
         "ru": {
@@ -12943,13 +12943,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "Đóng"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignorar"
+            "value": "닫기"
           }
         },
         "fr": {
@@ -13001,7 +13001,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "充電状態が変化すると、フローティング Dynamic Island スタイルの HUD を表示します。"
           }
         },
         "zh-Hans": {
@@ -13013,7 +13013,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "當充電狀態改變時，顯示浮動的 Dynamic Island 式 HUD。"
           }
         },
         "ru": {
@@ -13049,13 +13049,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "Hiển thị HUD kiểu Dynamic Island nổi khi trạng thái sạc thay đổi."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar um HUD flutuante ao estilo Dynamic Island quando o estado de carregamento mudar."
+            "value": "충전 상태가 변경되면 플로팅 Dynamic Island 스타일 HUD를 표시합니다."
           }
         },
         "fr": {
@@ -13107,7 +13107,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "メニューバーアイコンの横または中にバッテリーの割合を表示します。"
           }
         },
         "zh-Hans": {
@@ -13119,7 +13119,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "在功能表列圖示旁或內部顯示電池百分比。"
           }
         },
         "ru": {
@@ -13155,13 +13155,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "Hiển thị phần trăm pin bên cạnh hoặc bên trong biểu tượng thanh menu."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar percentagem da bateria junto ou dentro do ícone da barra de menu."
+            "value": "메뉴 표시줄 아이콘 옆이나 내부에 배터리 비율을 표시합니다."
           }
         },
         "fr": {
@@ -13213,7 +13213,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "表示モード"
           }
         },
         "zh-Hans": {
@@ -13225,7 +13225,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "顯示方式"
           }
         },
         "ru": {
@@ -13261,13 +13261,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "Chế độ hiển thị"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de exibição"
+            "value": "디스플레이 모드"
           }
         },
         "fr": {
@@ -13425,7 +13425,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "充電上限まで放電中"
           }
         },
         "zh-Hans": {
@@ -13437,7 +13437,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "正在放電至充電上限"
           }
         },
         "ru": {
@@ -13473,13 +13473,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "Đang xả pin đến giới hạn sạc"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A descarregar até ao limite"
+            "value": "충전 한도까지 방전 중"
           }
         },
         "fr": {
@@ -13638,7 +13638,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "期間"
           }
         },
         "zh-Hans": {
@@ -13650,7 +13650,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "持續時間"
           }
         },
         "ru": {
@@ -13686,13 +13686,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "Thời lượng"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duração"
+            "value": "기간"
           }
         },
         "fr": {
@@ -14279,7 +14279,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "自動キャリブレーションを有効にする"
           }
         },
         "zh-Hans": {
@@ -14291,7 +14291,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "啟用自動校準"
           }
         },
         "ru": {
@@ -14327,13 +14327,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "Bật hiệu chuẩn tự động"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar calibração automática"
+            "value": "자동 보정 활성화"
           }
         },
         "fr": {
@@ -14385,7 +14385,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "熱保護を有効にする"
           }
         },
         "zh-Hans": {
@@ -14397,7 +14397,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "啟用熱防護"
           }
         },
         "ru": {
@@ -14433,13 +14433,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "Kích hoạt tính năng bảo vệ nhiệt"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar proteção térmica"
+            "value": "열 보호 활성화"
           }
         },
         "fr": {
@@ -15347,7 +15347,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "セーリングモードを有効にする"
           }
         },
         "zh-Hans": {
@@ -15359,7 +15359,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "啟用航行模式"
           }
         },
         "ru": {
@@ -15395,13 +15395,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "Bật Chế độ Trôi dạt"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar modo navegação (Sailing Mode)"
+            "value": "세일링 모드 활성화"
           }
         },
         "fr": {
@@ -15879,7 +15879,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "14日ごと"
           }
         },
         "zh-Hans": {
@@ -15891,7 +15891,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "每 14 天一次"
           }
         },
         "ru": {
@@ -15927,13 +15927,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "Cứ sau 14 ngày"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 14 dias"
+            "value": "14일마다"
           }
         },
         "fr": {
@@ -15985,7 +15985,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "30日ごと"
           }
         },
         "zh-Hans": {
@@ -15997,7 +15997,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "每 30 天一次"
           }
         },
         "ru": {
@@ -16033,13 +16033,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "Cứ sau 30 ngày"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 30 dias"
+            "value": "30일마다"
           }
         },
         "fr": {
@@ -16091,7 +16091,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "60日ごと"
           }
         },
         "zh-Hans": {
@@ -16103,7 +16103,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "每 60 天"
           }
         },
         "ru": {
@@ -16139,13 +16139,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "Cứ sau 60 ngày"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 60 dias"
+            "value": "60일마다"
           }
         },
         "fr": {
@@ -16197,7 +16197,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "7日ごと"
           }
         },
         "zh-Hans": {
@@ -16209,7 +16209,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "每7天一次"
           }
         },
         "ru": {
@@ -16245,13 +16245,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "Cứ 7 ngày một lần"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cada 7 dias"
+            "value": "7일마다"
           }
         },
         "fr": {
@@ -16423,13 +16423,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "充電ヘルパーのインストールに失敗しました"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "충전 도우미 설치 실패"
           }
         },
         "nl": {
@@ -16477,7 +16477,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "Không cài đặt được trình trợ giúp sạc"
           }
         },
         "zh-Hans": {
@@ -16489,7 +16489,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao instalar auxiliar de carregamento"
+            "value": "充電助手安裝失敗"
           }
         }
       }
@@ -16530,13 +16530,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "充電ヘルパーのアンインストールに失敗しました"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "충전 도우미를 제거하지 못했습니다."
           }
         },
         "nl": {
@@ -16584,7 +16584,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "Không thể gỡ cài đặt trình trợ giúp sạc"
           }
         },
         "zh-Hans": {
@@ -16596,7 +16596,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falha ao desinstalar auxiliar de carregamento"
+            "value": "充電助手卸載失敗"
           }
         }
       }
@@ -16625,7 +16625,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "信頼性の高い充電管理を行うには、**[システム設定] → [バッテリー]** で [バッテリー充電の最適化] が無効になっていること、および Apple のネイティブの充電制限が正確に **%@** であることを確認してください。"
           }
         },
         "zh-Hans": {
@@ -16637,7 +16637,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "為了實現可靠的充電管理，請確保禁用“優化電池充電”，並且 Apple 的本機充電限制恰好位於 **系統設定 → 電池** 中的 **%@**。"
           }
         },
         "ru": {
@@ -16673,13 +16673,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "Để quản lý sạc đáng tin cậy, hãy đảm bảo rằng bạn đã tắt \"Tối ưu hóa sạc pin\" và Giới hạn sạc gốc của Apple chính xác ở **%@** trong **Cài đặt hệ thống → Pin**."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Para uma gestão de carga fiável, certifique-se de que \"Carregamento otimizado\" está desativado e que o limite nativo da Apple está exatamente a **%@** em **Definições do Sistema → Bateria**."
+            "value": "안정적인 충전 관리를 위해 \"배터리 충전 최적화\"가 비활성화되어 있고 Apple의 기본 충전 한도가 **시스템 설정 → 배터리**에서 정확히 **%@**에 있는지 확인하세요."
           }
         },
         "fr": {
@@ -16731,7 +16731,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "強制放電"
           }
         },
         "zh-Hans": {
@@ -16743,7 +16743,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "強制放電"
           }
         },
         "ru": {
@@ -16779,13 +16779,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "Xả pin cưỡng bức"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Forçar descarga"
+            "value": "강제 방전"
           }
         },
         "fr": {
@@ -17158,7 +17158,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "強制放電中"
           }
         },
         "zh-Hans": {
@@ -17170,7 +17170,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "強制放電中"
           }
         },
         "ru": {
@@ -17206,13 +17206,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "Đang xả pin cưỡng bức"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A forçar descarga"
+            "value": "강제 방전 중"
           }
         },
         "fr": {
@@ -17477,7 +17477,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "フル充電済み"
           }
         },
         "zh-Hans": {
@@ -17489,7 +17489,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "充滿電"
           }
         },
         "ru": {
@@ -17525,13 +17525,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "Đã sạc đầy"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Totalmente carregada"
+            "value": "완전히 충전됨"
           }
         },
         "fr": {
@@ -17689,7 +17689,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "メニューのドロップダウンに表示される一般的なシステムおよびバッテリーのステータス情報。"
           }
         },
         "zh-Hans": {
@@ -17701,7 +17701,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "一般系統和電池狀態資訊顯示在選單下拉清單中。"
           }
         },
         "ru": {
@@ -17737,13 +17737,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "Thông tin chung về hệ thống và trạng thái pin được hiển thị trong menu thả xuống."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informações gerais do sistema e do estado da bateria apresentadas no menu suspenso."
+            "value": "메뉴 드롭다운에 일반 시스템 및 배터리 상태 정보가 표시됩니다."
           }
         },
         "fr": {
@@ -18222,7 +18222,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "緑"
           }
         },
         "zh-Hans": {
@@ -18234,7 +18234,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "綠色"
           }
         },
         "ru": {
@@ -18270,13 +18270,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "màu xanh lá cây"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verde"
+            "value": "녹색"
           }
         },
         "fr": {
@@ -18328,7 +18328,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "バッテリーの状態"
           }
         },
         "zh-Hans": {
@@ -18340,7 +18340,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "電池健康度"
           }
         },
         "ru": {
@@ -18376,13 +18376,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "Tình trạng pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saúde"
+            "value": "배터리 성능 상태"
           }
         },
         "fr": {
@@ -18434,7 +18434,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "熱保護"
           }
         },
         "zh-Hans": {
@@ -18446,7 +18446,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "熱防護"
           }
         },
         "ru": {
@@ -18482,13 +18482,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "Bảo vệ nhiệt"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proteção térmica"
+            "value": "열 보호"
           }
         },
         "fr": {
@@ -18981,13 +18981,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "ヘルパー デーモンが正常にインストールされました。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "도우미 데몬이 성공적으로 설치되었습니다."
           }
         },
         "nl": {
@@ -19035,7 +19035,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "Trình trợ giúp đã được cài đặt thành công."
           }
         },
         "zh-Hans": {
@@ -19047,7 +19047,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar instalado com sucesso."
+            "value": "助手守護程序已成功安裝。"
           }
         }
       }
@@ -19088,13 +19088,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "ヘルパー デーモンが正常にアンインストールされました。アプリが再起動されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "도우미 데몬이 성공적으로 제거되었습니다. 이제 앱이 다시 시작됩니다."
           }
         },
         "nl": {
@@ -19142,7 +19142,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "Trình trợ giúp đã được gỡ cài đặt thành công. Ứng dụng bây giờ sẽ khởi động lại."
           }
         },
         "zh-Hans": {
@@ -19154,7 +19154,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar desinstalado com sucesso. A aplicação vai ser reiniciada."
+            "value": "助手守護程序已成功卸載。該應用程式現在將重新啟動。"
           }
         }
       }
@@ -19819,7 +19819,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "ヘルパーデーモンをインストールする"
           }
         },
         "zh-Hans": {
@@ -19831,7 +19831,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "安裝幫助守護程式"
           }
         },
         "ru": {
@@ -19867,13 +19867,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "Cài đặt trình nền trợ giúp"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalar serviço auxiliar (daemon)"
+            "value": "도우미 데몬 설치"
           }
         },
         "fr": {
@@ -20032,7 +20032,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "間隔"
           }
         },
         "zh-Hans": {
@@ -20044,7 +20044,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "間隔"
           }
         },
         "ru": {
@@ -20080,13 +20080,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "Khoảng thời gian"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intervalo"
+            "value": "간격"
           }
         },
         "fr": {
@@ -20139,7 +20139,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "予定されていたバッテリー調整の時期が来ました。これにより、再充電する前に Mac が %@ まで放電されます。"
           }
         },
         "zh-Hans": {
@@ -20151,7 +20151,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "是時候進行預定的電池校準了。這會將您的 Mac 在充電前放電至 %@。"
           }
         },
         "ru": {
@@ -20187,13 +20187,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "Đã đến lúc hiệu chỉnh pin theo lịch trình của bạn. Thao tác này sẽ xả máy Mac của bạn về %@ trước khi sạc lại."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chegou o momento da calibração programada da bateria. O Mac será descarregado até %@ antes de recarregar."
+            "value": "예약된 배터리 보정 시간입니다. 이렇게 하면 재충전하기 전에 Mac이 %@로 방전됩니다."
           }
         },
         "fr": {
@@ -20245,7 +20245,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "熱保護中のLED"
           }
         },
         "zh-Hans": {
@@ -20257,7 +20257,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "熱保護期間 LED"
           }
         },
         "ru": {
@@ -20293,13 +20293,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "LED trong quá trình bảo vệ nhiệt"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "LED durante proteção térmica"
+            "value": "열 보호 중 LED"
           }
         },
         "fr": {
@@ -20351,7 +20351,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "言語"
           }
         },
         "zh-Hans": {
@@ -20363,7 +20363,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "語言"
           }
         },
         "ru": {
@@ -20399,13 +20399,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "Ngôn ngữ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idioma"
+            "value": "언어"
           }
         },
         "fr": {
@@ -20457,7 +20457,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "最後に校正されたのは %@ です"
           }
         },
         "zh-Hans": {
@@ -20469,7 +20469,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "最後一次在 %@ 上校準"
           }
         },
         "ru": {
@@ -20505,13 +20505,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "Hiệu chỉnh lần cuối trên %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Última calibração em %@"
+            "value": "%@에서 마지막으로 교정됨"
           }
         },
         "fr": {
@@ -20563,7 +20563,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "ログイン時に起動"
           }
         },
         "zh-Hans": {
@@ -20575,7 +20575,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "登入時啟動"
           }
         },
         "ru": {
@@ -20611,13 +20611,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "Khởi chạy khi đăng nhập"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir no início de sessão"
+            "value": "로그인 시 실행"
           }
         },
         "fr": {
@@ -20776,7 +20776,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "限界に達しました"
           }
         },
         "zh-Hans": {
@@ -20788,7 +20788,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "已達到限制"
           }
         },
         "ru": {
@@ -20824,13 +20824,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "Đã đạt đến giới hạn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite atingido"
+            "value": "한도 도달"
           }
         },
         "fr": {
@@ -20882,7 +20882,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "バッテリーの寿命を延ばすために最大充電レベルを制限します。"
           }
         },
         "zh-Hans": {
@@ -20894,7 +20894,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "限制最大充電水平以延長電池壽命。"
           }
         },
         "ru": {
@@ -20930,13 +20930,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "Giới hạn mức sạc tối đa để kéo dài tuổi thọ pin."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitar o nível máximo de carga para prolongar a vida útil da bateria."
+            "value": "배터리 수명을 연장하려면 최대 충전 수준을 제한하세요."
           }
         },
         "fr": {
@@ -20988,7 +20988,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "低電力モード"
           }
         },
         "zh-Hans": {
@@ -21000,7 +21000,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "低耗電模式"
           }
         },
         "ru": {
@@ -21036,13 +21036,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "Chế độ năng lượng thấp"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo de baixo consumo"
+            "value": "저전력 모드"
           }
         },
         "fr": {
@@ -21094,7 +21094,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Mac ディスプレイのみ"
           }
         },
         "zh-Hans": {
@@ -21106,7 +21106,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "僅限 Mac 顯示器"
           }
         },
         "ru": {
@@ -21142,13 +21142,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Chỉ hiển thị máy Mac"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas ecrã do Mac"
+            "value": "Mac 디스플레이 전용"
           }
         },
         "fr": {
@@ -21200,7 +21200,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED コントロール"
           }
         },
         "zh-Hans": {
@@ -21212,7 +21212,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED 控制"
           }
         },
         "ru": {
@@ -21248,13 +21248,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "Điều khiển đèn LED MagSafe"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlo do LED MagSafe"
+            "value": "MagSafe LED 제어"
           }
         },
         "fr": {
@@ -21520,7 +21520,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "MagSafe LED 制御はこのデバイスではサポートされていません。"
           }
         },
         "zh-Hans": {
@@ -21532,7 +21532,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "本裝置不支援 MagSafe LED 控制。"
           }
         },
         "ru": {
@@ -21568,13 +21568,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "Điều khiển MagSafe LED không được hỗ trợ trên thiết bị này."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O controlo do LED MagSafe não é suportado neste dispositivo."
+            "value": "이 장치에서는 MagSafe LED 제어가 지원되지 않습니다."
           }
         },
         "fr": {
@@ -21840,7 +21840,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "MagSafe LED の管理"
           }
         },
         "zh-Hans": {
@@ -21852,7 +21852,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "管理 MagSafe LED"
           }
         },
         "ru": {
@@ -21888,13 +21888,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "Quản lý đèn LED MagSafe"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir LED MagSafe"
+            "value": "MagSafe LED 관리"
           }
         },
         "fr": {
@@ -21946,7 +21946,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "充電を管理する"
           }
         },
         "zh-Hans": {
@@ -21958,7 +21958,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "管理充電"
           }
         },
         "ru": {
@@ -21994,13 +21994,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "Quản lý sạc"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerir carregamento"
+            "value": "충전 관리"
           }
         },
         "fr": {
@@ -22266,7 +22266,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "メニューバーアイコン"
           }
         },
         "zh-Hans": {
@@ -22278,7 +22278,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "選單列圖示"
           }
         },
         "ru": {
@@ -22314,13 +22314,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "Biểu tượng thanh menu"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ícone da barra de menu"
+            "value": "메뉴바 아이콘"
           }
         },
         "fr": {
@@ -22372,7 +22372,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "メニューコントロール"
           }
         },
         "zh-Hans": {
@@ -22384,7 +22384,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "選單控制"
           }
         },
         "ru": {
@@ -22420,13 +22420,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "Điều khiển menu"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controlos do menu"
+            "value": "메뉴 컨트롤"
           }
         },
         "fr": {
@@ -22478,7 +22478,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "毎月"
           }
         },
         "zh-Hans": {
@@ -22490,7 +22490,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "每月"
           }
         },
         "ru": {
@@ -22526,13 +22526,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "hàng tháng"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mensalmente"
+            "value": "월간"
           }
         },
         "fr": {
@@ -23541,7 +23541,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "通知のみ"
           }
         },
         "zh-Hans": {
@@ -23553,7 +23553,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "僅通知"
           }
         },
         "ru": {
@@ -23589,13 +23589,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "Chỉ thông báo"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas notificar"
+            "value": "알림만"
           }
         },
         "fr": {
@@ -23859,7 +23859,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "バッテリー駆動"
           }
         },
         "zh-Hans": {
@@ -23871,7 +23871,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "電池供電"
           }
         },
         "ru": {
@@ -23907,13 +23907,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "Trên pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "A usar bateria"
+            "value": "배터리 사용"
           }
         },
         "fr": {
@@ -23965,7 +23965,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "保留中"
           }
         },
         "zh-Hans": {
@@ -23977,7 +23977,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "保留"
           }
         },
         "ru": {
@@ -24013,13 +24013,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "Đang chờ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em espera"
+            "value": "보류 중"
           }
         },
         "fr": {
@@ -24927,7 +24927,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "設定を開く"
           }
         },
         "zh-Hans": {
@@ -24939,7 +24939,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "開啟設定"
           }
         },
         "ru": {
@@ -24975,13 +24975,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "Mở cài đặt"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abrir Definições"
+            "value": "설정 열기"
           }
         },
         "fr": {
@@ -25461,7 +25461,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "オレンジ"
           }
         },
         "zh-Hans": {
@@ -25473,7 +25473,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "橘色"
           }
         },
         "ru": {
@@ -25509,13 +25509,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "trái cam"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laranja"
+            "value": "오렌지"
           }
         },
         "fr": {
@@ -25567,7 +25567,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "元々はオープンソース ベースからフォークされたもので、その後新しい機能を追加してさらに開発されました。"
           }
         },
         "zh-Hans": {
@@ -25579,7 +25579,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "最初是從開源基礎上分叉出來的，然後透過新功能進一步發展。"
           }
         },
         "ru": {
@@ -25615,13 +25615,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "Ban đầu được phân nhánh từ cơ sở nguồn mở, sau đó được phát triển thêm với các tính năng mới."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Originalmente derivado de uma base de código aberto, e posteriormente desenvolvido com novas funcionalidades."
+            "value": "원래 오픈 소스 기반에서 분기된 후 새로운 기능으로 추가 개발되었습니다."
           }
         },
         "fr": {
@@ -25673,7 +25673,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "出力ポート"
           }
         },
         "zh-Hans": {
@@ -25685,7 +25685,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "輸出埠"
           }
         },
         "ru": {
@@ -25721,13 +25721,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "Cổng đầu ra"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Portas de saída"
+            "value": "출력 포트"
           }
         },
         "fr": {
@@ -25779,7 +25779,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "出力ポートのテキスト行"
           }
         },
         "zh-Hans": {
@@ -25791,7 +25791,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "輸出連接埠文字行"
           }
         },
         "ru": {
@@ -25827,13 +25827,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "Hàng văn bản cổng đầu ra"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Linha de texto das portas de saída"
+            "value": "출력 포트 텍스트 행"
           }
         },
         "fr": {
@@ -25885,7 +25885,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "バッテリー温度がしきい値を超えた場合は、充電を一時停止します。"
           }
         },
         "zh-Hans": {
@@ -25897,7 +25897,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "當電池溫度超過閾值時暫停充電。"
           }
         },
         "ru": {
@@ -25933,13 +25933,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "Tạm dừng sạc khi nhiệt độ pin vượt quá ngưỡng."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pausar o carregamento quando a temperatura da bateria exceder o limiar."
+            "value": "배터리 온도가 임계값을 초과하면 충전을 일시 중지합니다."
           }
         },
         "fr": {
@@ -26098,7 +26098,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "正確なバッテリー容量の測定値を維持するために、完全な放電と再充電のサイクルを定期的に実行してください。"
           }
         },
         "zh-Hans": {
@@ -26110,7 +26110,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "定期運行完整的放電和充電週期，以保持準確的電池容量讀數。"
           }
         },
         "ru": {
@@ -26146,13 +26146,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "Định kỳ thực hiện chu trình xả và sạc đầy hoàn toàn để duy trì chỉ số dung lượng pin chính xác."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Executar periodicamente um ciclo completo de descarga e carga para manter leituras exatas da capacidade da bateria."
+            "value": "정확한 배터리 용량 판독값을 유지하려면 주기적으로 전체 방전 및 재충전 주기를 실행하십시오."
           }
         },
         "fr": {
@@ -26217,13 +26217,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "システム設定 -> 一般 -> ログイン項目を開き、Stasis がバックグラウンドで実行できるようにしてから、再試行してください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "시스템 설정 -> 일반 -> 로그인 항목을 열고 Stasis가 백그라운드에서 실행되도록 허용한 후 다시 시도하세요."
           }
         },
         "nl": {
@@ -26271,7 +26271,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "Vui lòng mở Cài đặt hệ thống -> Chung -> Mục đăng nhập và cho phép Stasis chạy ở chế độ nền, sau đó thử lại."
           }
         },
         "zh-Hans": {
@@ -26283,7 +26283,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Por favor abra Definições do Sistema -> Geral -> Itens de Início, permita que o Stasis execute em segundo plano e tente novamente."
+            "value": "請開啟「系統設定」->「一般」->「登入項目」，允許 Stasis 在背景執行，然後再試一次。"
           }
         }
       }
@@ -26311,7 +26311,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "プラグイン済み"
           }
         },
         "zh-Hans": {
@@ -26323,7 +26323,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "已接通電源"
           }
         },
         "ru": {
@@ -26359,13 +26359,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "Đã cắm vào"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente"
+            "value": "연결됨"
           }
         },
         "fr": {
@@ -26417,7 +26417,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "接続されています (充電されていません)"
           }
         },
         "zh-Hans": {
@@ -26429,7 +26429,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "已接通電源（未充電）"
           }
         },
         "ru": {
@@ -26465,13 +26465,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "Đã cắm điện (Không sạc)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ligada à corrente (Sem carregar)"
+            "value": "연결됨(충전 중이 아님)"
           }
         },
         "fr": {
@@ -26841,7 +26841,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "パワー"
           }
         },
         "zh-Hans": {
@@ -26853,7 +26853,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "電源"
           }
         },
         "ru": {
@@ -26889,13 +26889,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "quyền lực"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Energia"
+            "value": "힘"
           }
         },
         "fr": {
@@ -26947,7 +26947,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "電源アダプター"
           }
         },
         "zh-Hans": {
@@ -26959,7 +26959,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "電源轉接器"
           }
         },
         "ru": {
@@ -26995,13 +26995,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "Bộ đổi nguồn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente"
+            "value": "전원 어댑터"
           }
         },
         "fr": {
@@ -27053,7 +27053,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "電源アダプター (%@ W)"
           }
         },
         "zh-Hans": {
@@ -27065,7 +27065,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "電源供應器(%@ W)"
           }
         },
         "ru": {
@@ -27101,13 +27101,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "Bộ đổi nguồn (%@ W)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%@ W)"
+            "value": "전원 어댑터(%@ W)"
           }
         },
         "fr": {
@@ -27159,7 +27159,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "電源アダプター (%d W)"
           }
         },
         "zh-Hans": {
@@ -27171,7 +27171,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "電源供應器(%d W)"
           }
         },
         "ru": {
@@ -27207,13 +27207,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "Bộ đổi nguồn (%d W)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%d W)"
+            "value": "전원 어댑터(%d W)"
           }
         },
         "fr": {
@@ -27265,7 +27265,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "電源アダプター (%lld W)"
           }
         },
         "zh-Hans": {
@@ -27277,7 +27277,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "電源供應器(%lld W)"
           }
         },
         "ru": {
@@ -27313,13 +27313,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "Bộ đổi nguồn (%lld W)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adaptador de corrente (%lld W)"
+            "value": "전원 어댑터(%lld W)"
           }
         },
         "fr": {
@@ -27371,7 +27371,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "電源のみ"
           }
         },
         "zh-Hans": {
@@ -27383,7 +27383,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "僅電源"
           }
         },
         "ru": {
@@ -27419,13 +27419,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "Chỉ nguồn điện"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apenas corrente"
+            "value": "전원만"
           }
         },
         "fr": {
@@ -27477,7 +27477,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "電源"
           }
         },
         "zh-Hans": {
@@ -27489,7 +27489,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "電源"
           }
         },
         "ru": {
@@ -27525,13 +27525,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Nguồn điện"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "전원"
           }
         },
         "fr": {
@@ -27583,7 +27583,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "配電図"
           }
         },
         "zh-Hans": {
@@ -27595,7 +27595,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "配電圖"
           }
         },
         "ru": {
@@ -27631,13 +27631,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "Sơ đồ phân phối điện"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagrama de distribuição de energia"
+            "value": "전력 분배 다이어그램"
           }
         },
         "fr": {
@@ -27689,7 +27689,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "電源"
           }
         },
         "zh-Hans": {
@@ -27701,7 +27701,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "電源"
           }
         },
         "ru": {
@@ -27737,13 +27737,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "Nguồn điện"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de alimentação"
+            "value": "전원"
           }
         },
         "fr": {
@@ -27902,7 +27902,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "充電制限に向けて充電中に Mac がスリープ状態になるのを防ぎます。制限に達するかアダプターが切断されると、スリープは再び有効になります。"
           }
         },
         "zh-Hans": {
@@ -27914,7 +27914,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "防止 Mac 在充電至充電限額時進入睡眠狀態。一旦達到限製或適配器斷開連接，睡眠就會重新啟用。"
           }
         },
         "ru": {
@@ -27950,13 +27950,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "Ngăn máy Mac của bạn chuyển sang chế độ ngủ trong khi sạc tới giới hạn sạc. Chế độ ngủ được kích hoạt lại sau khi đạt đến giới hạn hoặc bộ điều hợp bị ngắt kết nối."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impedir que o Mac suspenda enquanto carrega até ao limite de carga. A suspensão é reativada quando o limite é atingido ou o carregador é desligado."
+            "value": "충전 한도까지 충전하는 동안 Mac이 잠자기 상태가 되지 않도록 하세요. 한도에 도달하거나 어댑터 연결이 끊어지면 절전 모드가 다시 활성화됩니다."
           }
         },
         "fr": {
@@ -28008,7 +28008,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "特権ヘルパー"
           }
         },
         "zh-Hans": {
@@ -28020,7 +28020,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "特權輔助程式"
           }
         },
         "ru": {
@@ -28056,13 +28056,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "Trình trợ giúp đặc quyền"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auxiliar com privilégios"
+            "value": "권한 있는 도우미"
           }
         },
         "fr": {
@@ -28433,7 +28433,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Stasis をやめますか?"
           }
         },
         "zh-Hans": {
@@ -28445,7 +28445,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "退出Stasis？"
           }
         },
         "ru": {
@@ -28481,13 +28481,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Thoát Stasis?"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis?"
+            "value": "Stasis를 종료하시겠습니까?"
           }
         },
         "fr": {
@@ -28539,7 +28539,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Stasis を終了すると、バックグラウンド ヘルパー サービスが停止します。バッテリーの充電制限と保護は機能しなくなります。"
           }
         },
         "zh-Hans": {
@@ -28551,7 +28551,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "結束 Stasis 將停止後台輔助服務，電池充電上限與保護功能將不再運作。"
           }
         },
         "ru": {
@@ -28587,13 +28587,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Việc thoát khỏi Stasis sẽ dừng các dịch vụ trợ giúp nền. Giới hạn và biện pháp bảo vệ sạc pin sẽ không còn hoạt động."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sair do Stasis irá parar os serviços auxiliares em segundo plano. Os limites de carregamento e proteções da bateria deixarão de funcionar."
+            "value": "Stasis를 종료하면 백그라운드 도우미 서비스가 중지됩니다. 배터리 충전 제한 및 보호 기능이 더 이상 작동하지 않습니다."
           }
         },
         "fr": {
@@ -28645,7 +28645,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "バグを報告する"
           }
         },
         "zh-Hans": {
@@ -28657,7 +28657,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "報告錯誤"
           }
         },
         "ru": {
@@ -28693,13 +28693,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "Báo cáo lỗi"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comunicar um erro"
+            "value": "버그 신고"
           }
         },
         "fr": {
@@ -28751,7 +28751,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "機能をリクエストする"
           }
         },
         "zh-Hans": {
@@ -28763,7 +28763,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "請求功能"
           }
         },
         "ru": {
@@ -28799,13 +28799,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "Yêu cầu một tính năng"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sugerir uma funcionalidade"
+            "value": "기능 요청"
           }
         },
         "fr": {
@@ -29390,7 +29390,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "%@ で休憩中..."
           }
         },
         "zh-Hans": {
@@ -29402,7 +29402,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "在 %@ 休息..."
           }
         },
         "ru": {
@@ -29438,13 +29438,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "Nghỉ ngơi tại %@..."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Em repouso a %@..."
+            "value": "%@에서 쉬고 있습니다..."
           }
         },
         "fr": {
@@ -29496,7 +29496,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "セーリングモード"
           }
         },
         "zh-Hans": {
@@ -29508,7 +29508,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "航行模式"
           }
         },
         "ru": {
@@ -29544,13 +29544,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "Chế độ Trôi dạt"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modo navegação (Sailing Mode)"
+            "value": "세일링 모드"
           }
         },
         "fr": {
@@ -30242,7 +30242,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Stasisの表示言語を選択します。変更を適用するには再起動が必要です。"
           }
         },
         "zh-Hans": {
@@ -30254,7 +30254,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "選擇 Stasis 的顯示語言。需要重新啟動才能套用變更。"
           }
         },
         "ru": {
@@ -30290,13 +30290,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Chọn ngôn ngữ hiển thị cho Stasis. Cần phải khởi động lại để áp dụng các thay đổi."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Selecione o idioma de exibição do Stasis. É necessário reiniciar para aplicar as alterações."
+            "value": "Stasis의 표시 언어를 선택합니다. 변경 사항을 적용하려면 다시 시작해야 합니다."
           }
         },
         "fr": {
@@ -32592,7 +32592,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Notch HUD に充電状態を表示"
           }
         },
         "zh-Hans": {
@@ -32604,7 +32604,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "在 Notch HUD 中顯示充電狀態"
           }
         },
         "ru": {
@@ -32640,13 +32640,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Hiển thị trạng thái sạc trong Notch HUD"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar estado de carregamento no Notch HUD"
+            "value": "Notch HUD에 충전 상태 표시"
           }
         },
         "fr": {
@@ -32698,7 +32698,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "手動充電コントロールを表示する"
           }
         },
         "zh-Hans": {
@@ -32710,7 +32710,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "顯示手動充電控制"
           }
         },
         "ru": {
@@ -32746,13 +32746,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "Hiển thị điều khiển sạc thủ công"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar controlos manuais de carregamento"
+            "value": "수동 충전 제어 표시"
           }
         },
         "fr": {
@@ -32804,7 +32804,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "ロック画面に表示する"
           }
         },
         "zh-Hans": {
@@ -32816,7 +32816,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "在鎖定畫面上顯示"
           }
         },
         "ru": {
@@ -32852,13 +32852,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "Hiển thị trên màn hình khóa"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar no ecrã de bloqueio"
+            "value": "잠금 화면에 표시"
           }
         },
         "fr": {
@@ -32910,7 +32910,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "出力電力を表示"
           }
         },
         "zh-Hans": {
@@ -32922,7 +32922,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "顯示輸出功率"
           }
         },
         "ru": {
@@ -32958,13 +32958,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "Hiển thị công suất đầu ra"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar energia de saída"
+            "value": "출력 전력 표시"
           }
         },
         "fr": {
@@ -33123,7 +33123,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "スリープ防止"
           }
         },
         "zh-Hans": {
@@ -33135,7 +33135,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "防止睡眠"
           }
         },
         "ru": {
@@ -33171,13 +33171,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "Ngăn chế độ ngủ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prevenção de suspensão"
+            "value": "잠자기 방지"
           }
         },
         "fr": {
@@ -33336,7 +33336,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "サウンド"
           }
         },
         "zh-Hans": {
@@ -33348,7 +33348,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "聲音"
           }
         },
         "ru": {
@@ -33384,13 +33384,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "Âm thanh"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Som"
+            "value": "소리"
           }
         },
         "fr": {
@@ -33549,7 +33549,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "今すぐキャリブレーションを開始"
           }
         },
         "zh-Hans": {
@@ -33561,7 +33561,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "立即開始校準"
           }
         },
         "ru": {
@@ -33597,13 +33597,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "Bắt đầu hiệu chỉnh ngay bây giờ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar calibração agora"
+            "value": "지금 교정 시작하기"
           }
         },
         "fr": {
@@ -34083,7 +34083,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "起動"
           }
         },
         "zh-Hans": {
@@ -34095,7 +34095,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "啟動"
           }
         },
         "ru": {
@@ -34131,13 +34131,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "Khởi động"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arranque"
+            "value": "시작"
           }
         },
         "fr": {
@@ -35579,7 +35579,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasisの設定"
           }
         },
         "zh-Hans": {
@@ -35591,7 +35591,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis 設定"
           }
         },
         "ru": {
@@ -35627,13 +35627,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Cài đặt Stasis"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Definições do Stasis"
+            "value": "Stasis 설정"
           }
         },
         "fr": {
@@ -35899,7 +35899,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Stasis バックグラウンド ヘルパーが正常に承認され、バックグラウンド充電がアクティブになりました。"
           }
         },
         "zh-Hans": {
@@ -35911,7 +35911,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Stasis 後台輔助程式已獲核准，後台充電功能現已啟用！"
           }
         },
         "ru": {
@@ -35947,13 +35947,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Trình trợ giúp nền Stasis đã được phê duyệt thành công và tính năng sạc nền hiện đang hoạt động!"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O auxiliar em segundo plano do Stasis foi aprovado com sucesso e o carregamento em segundo plano está ativo!"
+            "value": "Stasis 백그라운드 도우미가 성공적으로 승인되었으며 이제 백그라운드 충전이 활성화되었습니다!"
           }
         },
         "fr": {
@@ -36112,7 +36112,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis はまだ承認されていません。\n\nログイン項目設定の [アプリのバックグラウンド アクティビティ] で Stasis の切り替えを有効にしてください。 Stasis が「ログイン時に開く」に追加されていることを確認することもできます。"
           }
         },
         "zh-Hans": {
@@ -36124,7 +36124,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis 尚未獲核准。\n\n請在「登入項目」設定的「App 背景活動」中開啟 Stasis。你也可以確認 Stasis 已加入「登入時開啟」。"
           }
         },
         "ru": {
@@ -36160,13 +36160,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis chưa được phê duyệt.\n\nVui lòng bật nút chuyển đổi cho Stasis trong 'Hoạt động nền ứng dụng' trong cài đặt Mục đăng nhập. Bạn cũng có thể muốn đảm bảo Stasis được thêm vào 'Mở khi đăng nhập'."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis ainda não foi aprovado.\n\nPor favor ative o Stasis em \"Atividade da aplicação em segundo plano\" nas definições de Itens de Início. Certifique-se também de que o Stasis está adicionado a \"Abrir no Início\"."
+            "value": "Stasis는 아직 승인되지 않았습니다.\n\n로그인 항목 설정의 '앱 백그라운드 활동'에서 Stasis 토글을 활성화하세요. Stasis가 '로그인 시 열기'에 추가되었는지 확인할 수도 있습니다."
           }
         },
         "fr": {
@@ -36325,7 +36325,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis はバックグラウンド ヘルパーとの接続を失いました。 [システム設定] > [一般] > [ログイン項目] に移動し、[バックグラウンドでの許可] の下で Stasis をオフにしてからオンに戻し、アプリを再起動してください。"
           }
         },
         "zh-Hans": {
@@ -36337,7 +36337,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis 已失去與後台輔助程式的連線。請前往「系統設定」>「一般」>「登入項目」，在「允許在背景執行」下先關閉再重新開啟 Stasis，然後重新啟動 App。"
           }
         },
         "ru": {
@@ -36373,13 +36373,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis mất kết nối với trình trợ giúp nền của nó. Vui lòng đi tới Cài đặt hệ thống > Cài đặt chung > Mục đăng nhập, tắt và bật lại Stasis trong phần 'Cho phép ở chế độ nền' và khởi động lại ứng dụng."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis perdeu a ligação ao auxiliar em segundo plano. Por favor vá a Definições do Sistema > Geral > Itens de Início, desative e volte a ativar o Stasis sob \"Permitir em segundo plano\" e reinicie a aplicação."
+            "value": "Stasis가 배경 도우미와의 연결을 끊었습니다. 시스템 설정 > 일반 > 로그인 항목으로 이동하여 '백그라운드에서 허용'에서 Stasis를 껐다가 다시 켜고 앱을 다시 시작하세요."
           }
         },
         "fr": {
@@ -36538,7 +36538,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis は Sparkle を使用して自動更新を処理します。"
           }
         },
         "zh-Hans": {
@@ -36550,7 +36550,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis 使用 Sparkle 來處理自動更新。"
           }
         },
         "ru": {
@@ -36586,13 +36586,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis sử dụng Sparkle để xử lý các cập nhật tự động."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Stasis utiliza o Sparkle para gerir atualizações automáticas."
+            "value": "Stasis는 Sparkle을 사용하여 자동 업데이트를 처리합니다."
           }
         },
         "fr": {
@@ -37176,7 +37176,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "システムのデフォルト"
           }
         },
         "zh-Hans": {
@@ -37188,7 +37188,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "系統預設值"
           }
         },
         "ru": {
@@ -37224,13 +37224,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "Mặc định hệ thống"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição do sistema"
+            "value": "시스템 기본값"
           }
         },
         "fr": {
@@ -37282,7 +37282,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "温度"
           }
         },
         "zh-Hans": {
@@ -37294,7 +37294,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "溫度"
           }
         },
         "ru": {
@@ -37330,13 +37330,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "Nhiệt độ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Temperatura"
+            "value": "온도"
           }
         },
         "fr": {
@@ -37495,7 +37495,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "温度制限"
           }
         },
         "zh-Hans": {
@@ -37507,7 +37507,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "溫度限制"
           }
         },
         "ru": {
@@ -37543,13 +37543,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "Giới hạn nhiệt độ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limite de temperatura"
+            "value": "온도 제한"
           }
         },
         "fr": {
@@ -38243,7 +38243,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "ヘルパー デーモンは、バッテリーの充電状態を管理するためにバックグラウンドで実行されます。\n\n注: macOS は、バックグラウンド ヘルパーが登録解除された後でも、意図的にアプリを「アプリのバックグラウンド アクティビティ」リスト (システム設定) に保持します。 [アンインストール] をクリックすると、ヘルパーは実際に無効になりますが、macOS では、アプリ自体が Mac から削除されるまで、そのリストに Stasis が表示されたままになります。"
           }
         },
         "zh-Hans": {
@@ -38255,7 +38255,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "後台輔助服務會在背景執行，以管理電池充電狀態。\n\n注意：即使後台輔助程式已取消註冊，macOS 仍會刻意將 App 保留在「App 背景活動」列表（系統設定）中。按下「解除安裝」後，輔助程式確實已停用，但在你從 Mac 刪除 Stasis App 之前，macOS 仍會讓 Stasis 顯示於該列表中。"
           }
         },
         "ru": {
@@ -38291,13 +38291,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "Trình nền của trình trợ giúp chạy trong nền để quản lý trạng thái sạc pin.\n\nLưu ý: macOS cố tình giữ lại các ứng dụng trong danh sách \"Hoạt động nền của ứng dụng\" (Cài đặt hệ thống) ngay cả sau khi trình trợ giúp nền của chúng chưa được đăng ký. Sau khi bạn nhấp vào Gỡ cài đặt, trình trợ giúp thực sự bị tắt nhưng macOS sẽ giữ Stasis hiển thị trong danh sách đó cho đến khi chính ứng dụng đó bị xóa khỏi máy Mac của bạn."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "O serviço auxiliar é executado em segundo plano para gerir os estados de carregamento da bateria.\n\nNota: o macOS mantém intencionalmente as aplicações na lista \"Atividade da aplicação em segundo plano\" mesmo após a remoção do auxiliar. Após clicar em Desinstalar, o auxiliar é realmente desativado, mas o macOS manterá o Stasis visível nessa lista até que a aplicação seja removida do Mac."
+            "value": "도우미 데몬은 백그라운드에서 실행되어 배터리 충전 상태를 관리합니다.\n\n참고: macOS는 백그라운드 도우미가 등록 취소된 후에도 의도적으로 앱을 \"앱 백그라운드 활동\" 목록(시스템 설정)에 유지합니다. 제거를 클릭하면 도우미가 실제로 비활성화되지만 macOS는 앱 자체가 Mac에서 삭제될 때까지 해당 목록에 Stasis를 계속 표시합니다."
           }
         },
         "fr": {
@@ -38349,7 +38349,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "限界値を下回るしきい値"
           }
         },
         "zh-Hans": {
@@ -38361,7 +38361,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "閾值低於限制"
           }
         },
         "ru": {
@@ -38397,13 +38397,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "Ngưỡng dưới giới hạn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limiar abaixo do limite"
+            "value": "한도 미만의 임계값"
           }
         },
         "fr": {
@@ -38455,7 +38455,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "残り時間"
           }
         },
         "zh-Hans": {
@@ -38467,7 +38467,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "剩餘時間"
           }
         },
         "ru": {
@@ -38503,13 +38503,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "Thời gian còn lại"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo restante"
+            "value": "남은 시간"
           }
         },
         "fr": {
@@ -38561,7 +38561,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "時刻"
           }
         },
         "zh-Hans": {
@@ -38573,7 +38573,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "一天中的時間"
           }
         },
         "ru": {
@@ -38609,13 +38609,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "Thời gian trong ngày"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hora do dia"
+            "value": "하루 중 시간"
           }
         },
         "fr": {
@@ -38667,7 +38667,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "放電までの時間"
           }
         },
         "zh-Hans": {
@@ -38679,7 +38679,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "距離放電的時間"
           }
         },
         "ru": {
@@ -38715,13 +38715,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "Thời gian đến khi xả pin"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo até descarregar"
+            "value": "방전까지 남은 시간"
           }
         },
         "fr": {
@@ -38892,13 +38892,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "ヒント: [システム設定] -> [一般] -> [ログイン項目] を確認します。 Stasis がバックグラウンドで実行できるようにしてください。すでにオンになっている場合は、オフにしてから再度オンにしてみてください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "팁: 시스템 설정 -> 일반 -> 로그인 항목을 확인하세요. Stasis가 백그라운드에서 실행될 수 있는지 확인하세요. 이미 켜져 있으면 껐다가 다시 켜보세요."
           }
         },
         "nl": {
@@ -38946,7 +38946,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "Mẹo: Kiểm tra Cài đặt hệ thống -> Chung -> Mục đăng nhập. Đảm bảo Stasis được phép chạy ở chế độ nền. Nếu nó đã được bật, hãy thử tắt và bật lại."
           }
         },
         "zh-Hans": {
@@ -38958,7 +38958,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dica: Verifique Definições do Sistema -> Geral -> Itens de Início. Certifique-se de que o Stasis tem permissão para executar em segundo plano. Se já estiver ativo, tente desativar e reativar."
+            "value": "提示：檢查系統設定->常規->登入項目。確保允許 Stasis 在背景運行。如果它已經打開，請嘗試將其關閉然後再次打開。"
           }
         }
       }
@@ -40377,7 +40377,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "上限まで充電"
           }
         },
         "zh-Hans": {
@@ -40389,7 +40389,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "充電至上限"
           }
         },
         "ru": {
@@ -40425,13 +40425,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "Sạc đến giới hạn"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carregar até ao limite"
+            "value": "한도까지 충전"
           }
         },
         "fr": {
@@ -41230,7 +41230,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "ヘルパーデーモンをアンインストールする"
           }
         },
         "zh-Hans": {
@@ -41242,7 +41242,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "卸載幫助守護程序"
           }
         },
         "ru": {
@@ -41278,13 +41278,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "Gỡ cài đặt trình nền trợ giúp"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desinstalar serviço auxiliar (daemon)"
+            "value": "도우미 데몬 제거"
           }
         },
         "fr": {
@@ -41349,13 +41349,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "不明"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "알 수 없음"
           }
         },
         "nl": {
@@ -41403,7 +41403,7 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "Không xác định"
           }
         },
         "zh-Hans": {
@@ -41415,7 +41415,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconhecido"
+            "value": "未知"
           }
         }
       }
@@ -41550,7 +41550,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "アップデート"
           }
         },
         "zh-Hans": {
@@ -41562,7 +41562,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "更新"
           }
         },
         "ru": {
@@ -41598,13 +41598,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "Cập nhật"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizações"
+            "value": "업데이트"
           }
         },
         "fr": {
@@ -41656,7 +41656,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "稼働時間"
           }
         },
         "zh-Hans": {
@@ -41668,7 +41668,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "正常運作時間"
           }
         },
         "ru": {
@@ -41704,13 +41704,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "Thời gian hoạt động"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tempo de atividade"
+            "value": "가동 시간"
           }
         },
         "fr": {
@@ -41762,7 +41762,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "ハードウェアのバッテリー残量を使用"
           }
         },
         "zh-Hans": {
@@ -41774,7 +41774,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "使用硬體回報的電池百分比"
           }
         },
         "ru": {
@@ -41810,13 +41810,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "Sử dụng phần trăm pin phần cứng"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar percentagem de hardware"
+            "value": "하드웨어 배터리 잔량 사용"
           }
         },
         "fr": {
@@ -41868,7 +41868,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "ハードウェアの生の状態値を使用"
           }
         },
         "zh-Hans": {
@@ -41880,7 +41880,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "使用原始硬體健康度"
           }
         },
         "ru": {
@@ -41916,13 +41916,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "Sử dụng giá trị tình trạng phần cứng thô"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar saúde bruta do hardware"
+            "value": "원시 하드웨어 상태 값 사용"
           }
         },
         "fr": {
@@ -41974,7 +41974,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "macOS の調整値の代わりに、生のバッテリーの割合を使用します。"
           }
         },
         "zh-Hans": {
@@ -41986,7 +41986,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "使用原始電池百分比而不是 macOS 校準值。"
           }
         },
         "ru": {
@@ -42022,13 +42022,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "Sử dụng phần trăm pin thô thay vì giá trị đã hiệu chỉnh macOS."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usar a percentagem bruta da bateria em vez do valor calibrado pelo macOS."
+            "value": "macOS 보정 값 대신 원시 배터리 비율을 사용합니다."
           }
         },
         "fr": {
@@ -42186,7 +42186,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "GitHub で見る"
           }
         },
         "zh-Hans": {
@@ -42198,7 +42198,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "在 GitHub 上查看"
           }
         },
         "ru": {
@@ -42234,13 +42234,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "Xem trên GitHub"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver no GitHub"
+            "value": "GitHub에서 보기"
           }
         },
         "fr": {
@@ -42292,7 +42292,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "表示"
           }
         },
         "zh-Hans": {
@@ -42304,7 +42304,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "外觀"
           }
         },
         "ru": {
@@ -42340,13 +42340,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "Hiển thị"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visuais"
+            "value": "시각 효과"
           }
         },
         "fr": {
@@ -42398,7 +42398,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "毎週"
           }
         },
         "zh-Hans": {
@@ -42410,7 +42410,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "每週"
           }
         },
         "ru": {
@@ -42446,13 +42446,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "hàng tuần"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Semanalmente"
+            "value": "주간"
           }
         },
         "fr": {
@@ -42611,7 +42611,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "アップデートが見つかったとき"
           }
         },
         "zh-Hans": {
@@ -42623,7 +42623,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "當發現更新時"
           }
         },
         "ru": {
@@ -42659,13 +42659,13 @@
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "Khi tìm thấy bản cập nhật"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quando forem encontradas atualizações"
+            "value": "업데이트가 발견되면"
           }
         },
         "fr": {

--- a/Stasis/Views/Settings/ShortcutsHelpView.swift
+++ b/Stasis/Views/Settings/ShortcutsHelpView.swift
@@ -133,7 +133,7 @@ struct ShortcutsHelpView: View {
                         .font(.subheadline)
                         .foregroundColor(.secondary)
 
-                    Text("open \"stasis://charge-limit?value=80\"")
+                    Text(verbatim: "open \"stasis://charge-limit?value=80\"")
                         .font(.system(.footnote, design: .monospaced))
                         .padding(8)
                         .background(Color(NSColor.textBackgroundColor))


### PR DESCRIPTION
## Summary

- Complete and repair localization coverage across the supported locales.
- Add missing Chinese translations for the Shortcuts help view.
- Refine localization terminology and formatting consistency.
- Render the `stasis://` command example as literal text.
- Document the original project that Stasis was forked from.

## Changes

- Updated `Stasis/L10n/Localizable.xcstrings`.
- Updated `Stasis/Views/Settings/ShortcutsHelpView.swift`.
- Updated `README.md`.

## Testing
- Built successfully in Debug configuration with Swift 6.3.2 and macOS Command Line Tools.