### PR TITLE
Enable multi-display support and dynamic notch width calculations

### DIFF
--- a/Stasis/Services/NotchHUDManager.swift
+++ b/Stasis/Services/NotchHUDManager.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 @MainActor
 class NotchHUDManager {
-    private let window: NotchWindow
+    private var windows: [NotchWindow] = []
     private let viewModel: MenuViewModel
     private var observationTask: Task<Void, Never>?
     private var hideTask: Task<Void, Never>?
@@ -23,12 +23,6 @@ class NotchHUDManager {
 
     init(viewModel: MenuViewModel) {
         self.viewModel = viewModel
-        self.window = NotchWindow()
-        // Override default shadow padding/height for our custom view
-        self.window.contentHeight = 36
-        self.window.shadowPadding = 0 // Tighter padding for a cleaner look
-        self.window.hasShadow = false // Fix grayish color blending
-
         startObserving()
     }
 
@@ -224,16 +218,11 @@ class NotchHUDManager {
                 targetScreens.append(mainScreen)
             }
         } else {
-            // Show on main screen or all screens. For simplicity, just use main screen if all displays
-            if let mainScreen = NSScreen.main {
-                targetScreens.append(mainScreen)
-            }
+            // Show on all screens
+            targetScreens = NSScreen.screens
         }
 
-        guard let targetScreen = targetScreens.first else { return }
-        let isPill = !NotchWindow.hasNotch(screen: targetScreen)
-
-        let wasVisible = window.isVisible
+        let wasVisible = !windows.isEmpty && windows.first?.isVisible == true
         
         // Ensure state starts collapsed if window is not visible
         if !wasVisible {
@@ -250,17 +239,62 @@ class NotchHUDManager {
         state.chargingMode = viewModel.chargingMode
         state.isLowPowerModeEnabled = viewModel.isLowPowerModeEnabled
         
-        // Ensure the window is shown with the view bound to our state
-        if window.contentView == nil || !wasVisible {
-            let contentView = ChargingNotchView(state: state)
-            if !isPill {
-                window.contentHeight = targetScreen.safeAreaInsets.top
-                window.showNotch(on: targetScreen, content: contentView)
-            } else {
-                window.contentHeight = 36
-                window.showPill(on: targetScreen, content: contentView)
-            }
+        // Match windows count to targetScreens
+        while windows.count < targetScreens.count {
+            let window = NotchWindow()
+            window.contentHeight = 36
+            window.shadowPadding = 0
+            window.hasShadow = false
+            windows.append(window)
+        }
+        while windows.count > targetScreens.count {
+            let window = windows.removeLast()
+            window.orderOut(nil)
+        }
+        
+        // Ensure the windows are shown with the view bound to our state
+        for (index, targetScreen) in targetScreens.enumerated() {
+            let window = windows[index]
             
+            if window.contentView == nil || !wasVisible {
+                var calculatedNotchWidth: CGFloat = 180.0
+                if #available(macOS 12.0, *) {
+                    if let leftArea = targetScreen.auxiliaryTopLeftArea,
+                       let rightArea = targetScreen.auxiliaryTopRightArea,
+                       leftArea.width > 0, rightArea.width > 0 {
+                        let gap = rightArea.minX - leftArea.maxX
+                        if gap > 0 {
+                            calculatedNotchWidth = gap
+                        }
+                    } else {
+                        // Responsive fallback
+                        let scale = targetScreen.frame.width / 1470.0
+                        calculatedNotchWidth = 180.0 * max(0.8, min(scale, 1.5))
+                    }
+                } else {
+                    let scale = targetScreen.frame.width / 1470.0
+                    calculatedNotchWidth = 180.0 * max(0.8, min(scale, 1.5))
+                }
+
+                let contentView = ChargingNotchView(state: state, notchWidth: calculatedNotchWidth)
+                let safeAreaTop = targetScreen.safeAreaInsets.top
+                let menuBarHeight = targetScreen.frame.maxY - targetScreen.visibleFrame.maxY
+                
+                let notchHeight: CGFloat
+                if safeAreaTop > 0 {
+                    notchHeight = safeAreaTop
+                } else if menuBarHeight > 0 {
+                    notchHeight = menuBarHeight
+                } else {
+                    notchHeight = 32 // Fallback if menu bar is hidden
+                }
+                
+                window.contentHeight = notchHeight
+                window.showNotch(on: targetScreen, content: contentView)
+            }
+        }
+        
+        if !wasVisible {
             // Trigger animation on next runloop tick so view is in hierarchy
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(50))
@@ -282,10 +316,12 @@ class NotchHUDManager {
             // Trigger SwiftUI collapse animation
             state.isVisible = false
             
-            // Wait for spring animation to finish then close window
+            // Wait for spring animation to finish then close windows
             try? await Task.sleep(for: .milliseconds(400))
             guard !Task.isCancelled else { return }
-            window.orderOut(nil)
+            for window in self.windows {
+                window.orderOut(nil)
+            }
         }
     }
 }

--- a/Stasis/Views/Notch/ChargingNotchView.swift
+++ b/Stasis/Views/Notch/ChargingNotchView.swift
@@ -32,11 +32,7 @@ class NotchHUDState {
         return 16 + 60 + 16 // battery is around 60 wide
     }
 
-    var dynamicWidth: CGFloat {
-        if !isVisible { return 180 }
-        return leftContentWidth + 180 + rightContentWidth
-    }
-    
+    // Math to keep the gap perfectly centered on screen despite an asymmetrical shape
     var correctionOffset: CGFloat {
         if !isVisible { return 0 }
         // Math to keep the 180 gap perfectly centered on screen despite an asymmetrical shape
@@ -46,6 +42,12 @@ class NotchHUDState {
 
 struct ChargingNotchView: View {
     var state: NotchHUDState
+    var notchWidth: CGFloat = 180
+
+    var dynamicWidth: CGFloat {
+        if !state.isVisible { return notchWidth }
+        return state.leftContentWidth + notchWidth + state.rightContentWidth
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -61,7 +63,7 @@ struct ChargingNotchView: View {
 
             // CENTER: The physical notch width
             Spacer()
-                .frame(width: 180) 
+                .frame(width: notchWidth) 
 
             // RIGHT SIDE: Battery
             BatteryIndicatorView(
@@ -79,7 +81,7 @@ struct ChargingNotchView: View {
             .clipped()
         }
         // Use dynamically calculated asymmetric width that perfectly wraps content
-        .frame(width: state.dynamicWidth)
+        .frame(width: dynamicWidth)
         .frame(maxHeight: .infinity)
         // Background and clip shape MUST be applied BEFORE offset so they perfectly wrap the asymmetric content
         .background(NotchShape().fill(.black))

--- a/Stasis/Views/Notch/NotchWindow.swift
+++ b/Stasis/Views/Notch/NotchWindow.swift
@@ -61,7 +61,7 @@ class NotchWindow: NSPanel {
         TopWindowElevator.shared.elevate(window: self)
     }
 
-    /// Show as a floating pill at the bottom of the screen (fallback for non-notch Macs).
+    /// Show as a floating pill at the top of the screen (fallback for non-notch Macs).
     func showPill<Content: View>(on screen: NSScreen, content: Content) {
         level = .floating
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
@@ -71,7 +71,8 @@ class NotchWindow: NSPanel {
         let totalHeight = contentHeight + shadowPadding
         
         let x = screen.frame.origin.x
-        let y = screen.visibleFrame.minY + 30
+        // Position below the menu bar
+        let y = screen.visibleFrame.maxY - totalHeight - 10
         setFrame(CGRect(x: x, y: y, width: totalWidth, height: totalHeight), display: false)
 
         let hosting = NSHostingView(rootView:


### PR DESCRIPTION
This pull request updates the Notch HUD system to support multiple displays, dynamically adapts the notch width and height for different screen configurations, and improves the layout logic for both notched and non-notched Macs.

**Multi-display support and dynamic layout improvements:**

* `Stasis/Services/NotchHUDManager.swift`:
  - Refactored `NotchHUDManager` to manage a list of `NotchWindow` instances (one per display) instead of a single window, enabling HUD display across all connected screens. [[1]](diffhunk://#diff-dd679d729a4e2ab2fa32055bbd847c30b186bdb052383f5b299fcecda2757907L9-R9) [[2]](diffhunk://#diff-dd679d729a4e2ab2fa32055bbd847c30b186bdb052383f5b299fcecda2757907L26-L31)
  - Updated logic to create, update, and remove windows as displays are added or removed, and to bind each window to its target screen. [[1]](diffhunk://#diff-dd679d729a4e2ab2fa32055bbd847c30b186bdb052383f5b299fcecda2757907L227-R225) [[2]](diffhunk://#diff-dd679d729a4e2ab2fa32055bbd847c30b186bdb052383f5b299fcecda2757907L253-R297)
  - Calculated notch width dynamically based on the physical notch gap (if present) or a responsive fallback for non-notched screens; also determined notch height based on safe area or menu bar height.
  - Ensured that window hiding/animation is handled for all windows.

**Charging HUD view and layout adjustments:**

* `Stasis/Views/Notch/ChargingNotchView.swift`:
  - Made `notchWidth` a parameter of `ChargingNotchView` and used it for dynamic layout calculations, ensuring correct sizing and centering on all screens. [[1]](diffhunk://#diff-52104024da92e1e5d2454ff7922e0c21c9f7c6790352e03e8b9f5b1b800c1f75R45-R50) [[2]](diffhunk://#diff-52104024da92e1e5d2454ff7922e0c21c9f7c6790352e03e8b9f5b1b800c1f75L64-R66) [[3]](diffhunk://#diff-52104024da92e1e5d2454ff7922e0c21c9f7c6790352e03e8b9f5b1b800c1f75L82-R84)
  - Removed the internal `dynamicWidth` property from state and moved it to the view for better encapsulation.

**Non-notch Mac improvements:**

* `Stasis/Views/Notch/NotchWindow.swift`:
  - Updated the fallback "pill" HUD to appear at the top of the screen (just below the menu bar), improving consistency and visibility on non-notched Macs. [[1]](diffhunk://#diff-9ab2ea44c6909878b1b9eb46ad0f013296927622273507c51c2ad97d0d729e98L64-R64) [[2]](diffhunk://#diff-9ab2ea44c6909878b1b9eb46ad0f013296927622273507c51c2ad97d0d729e98L74-R75)
