### PR TITLE
Add MagSafe LED control and improve charging mode display logic

### DIFF
--- a/Stasis/Services/CalibrationManager.swift
+++ b/Stasis/Services/CalibrationManager.swift
@@ -113,9 +113,15 @@ class CalibrationManager {
                         Defaults[.calibrationStatus] = .charging
                         try await batteryService.enablePowerAdapter()
                         try await batteryService.chargeToFull()
+                        if Defaults[.manageMagSafeLED] {
+                            try await batteryService.manageMagsafeLED(target: Defaults[.chargingMagSafeLEDState])
+                        }
                     } else {
                         // Ensure it's discharging
                         try await batteryService.disablePowerAdapter()
+                        if Defaults[.manageMagSafeLED] {
+                            try await batteryService.manageMagsafeLED(target: Defaults[.dischargingMagSafeLEDState])
+                        }
                     }
                     batteryService.scheduleSinglePoll()
                 case .charging:
@@ -125,11 +131,17 @@ class CalibrationManager {
                         logger.info("Charging step complete. Moving to resting step.")
                         Defaults[.calibrationStatus] = .resting
                         Defaults[.calibrationStepStartTime] = Date()
-                        // Keep it topped up during rest
-                        try await batteryService.chargeToFull()
+                        // Keep it resting at 100% using adapter power
+                        try await batteryService.disableCharging()
+                        if Defaults[.manageMagSafeLED] {
+                            try await batteryService.manageMagsafeLED(target: Defaults[.pausedMagSafeLEDState])
+                        }
                     } else {
                         // Ensure it's charging
                         try await batteryService.chargeToFull()
+                        if Defaults[.manageMagSafeLED] {
+                            try await batteryService.manageMagsafeLED(target: Defaults[.chargingMagSafeLEDState])
+                        }
                     }
                     batteryService.scheduleSinglePoll()
                 case .resting:
@@ -142,8 +154,11 @@ class CalibrationManager {
                     if elapsedMinutes >= 120.0 {
                         finishCalibration()
                     } else {
-                        // Keep it resting and topped up
-                        try await batteryService.chargeToFull()
+                        // Keep it resting and use adapter power
+                        try await batteryService.disableCharging()
+                        if Defaults[.manageMagSafeLED] {
+                            try await batteryService.manageMagsafeLED(target: Defaults[.pausedMagSafeLEDState])
+                        }
                     }
                 case .idle:
                     break

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -230,7 +230,7 @@ class MenuViewModel {
                 batteryModeText = String(localized: "Calibrating (Discharging to \(15.formattedPercentage))")
             case .charging:
                 if logicallyPluggedIn {
-                    chargingMode = .charging
+                    chargingMode = safeMetrics.isCharging ? .charging : .pluggedIn
                     batteryModeText = String(localized: "Calibrating (Charging to \(100.formattedPercentage))")
                 } else {
                     chargingMode = .discharging
@@ -238,7 +238,7 @@ class MenuViewModel {
                 }
             case .resting:
                 if logicallyPluggedIn {
-                    chargingMode = .pluggedIn
+                    chargingMode = safeMetrics.isCharging ? .charging : .pluggedIn
                     batteryModeText = String(localized: "Calibrating (Resting at \(100.formattedPercentage))")
                 } else {
                     chargingMode = .discharging


### PR DESCRIPTION
This pull request enhances the calibration workflow by improving MagSafe LED management and refining how charging states are displayed in the menu. The most important changes include conditional control of the MagSafe LED during calibration steps and more accurate representation of the charging mode in the UI.

**Calibration workflow improvements:**

* Added conditional logic to manage the MagSafe LED state during charging, discharging, and resting steps of calibration, based on user defaults. This ensures the LED accurately reflects the current calibration phase. [[1]](diffhunk://#diff-b611e25053556b6335c807a4591b430c8da95ea4bc5484b951653e024b009535R116-R124) [[2]](diffhunk://#diff-b611e25053556b6335c807a4591b430c8da95ea4bc5484b951653e024b009535L128-R144) [[3]](diffhunk://#diff-b611e25053556b6335c807a4591b430c8da95ea4bc5484b951653e024b009535L145-R161)

**User interface enhancements:**

* Updated the logic in `MenuViewModel` to set the `chargingMode` based on the actual charging state (`isCharging`) rather than just whether the device is plugged in, providing a more accurate status during calibration.