### PR TITLE
Enforce XPC security and add input validation for charging settings

### DIFF
--- a/ChargingHelper/ChargingSettings.swift
+++ b/ChargingHelper/ChargingSettings.swift
@@ -122,17 +122,23 @@ enum ChargingSettings {
             case "manageCharging":
                 manageCharging = value as? Bool ?? manageCharging
             case "chargeLimit":
-                chargeLimit = UInt8(value as? Int ?? Int(chargeLimit))
+                if let intVal = value as? Int {
+                    chargeLimit = UInt8(clamping: max(50, min(100, intVal)))
+                }
             case "sailingMode":
                 sailingMode = value as? Bool ?? sailingMode
             case "sailingModeLimit":
-                sailingModeLimit = UInt8(value as? Int ?? Int(sailingModeLimit))
+                if let intVal = value as? Int {
+                    sailingModeLimit = UInt8(clamping: max(1, min(100, intVal)))
+                }
             case "automaticDischarge":
                 automaticDischarge = value as? Bool ?? automaticDischarge
             case "enableHeatProtectionMode":
                 enableHeatProtectionMode = value as? Bool ?? enableHeatProtectionMode
             case "heatProtectionLimit":
-                heatProtectionLimit = value as? Int ?? heatProtectionLimit
+                if let intVal = value as? Int {
+                    heatProtectionLimit = max(20, min(60, intVal))
+                }
             case "disableSleepUntilChargeLimit":
                 disableSleepUntilChargeLimit = value as? Bool ?? disableSleepUntilChargeLimit
             case "disableSleepWhileDischarging":
@@ -140,13 +146,21 @@ enum ChargingSettings {
             case "manageMagSafeLED":
                 manageMagSafeLED = value as? Bool ?? manageMagSafeLED
             case "chargingMagSafeLEDState":
-                chargingMagSafeLEDState = UInt8(value as? Int ?? Int(chargingMagSafeLEDState))
+                if let intVal = value as? Int {
+                    chargingMagSafeLEDState = UInt8(clamping: intVal)
+                }
             case "pausedMagSafeLEDState":
-                pausedMagSafeLEDState = UInt8(value as? Int ?? Int(pausedMagSafeLEDState))
+                if let intVal = value as? Int {
+                    pausedMagSafeLEDState = UInt8(clamping: intVal)
+                }
             case "dischargingMagSafeLEDState":
-                dischargingMagSafeLEDState = UInt8(value as? Int ?? Int(dischargingMagSafeLEDState))
+                if let intVal = value as? Int {
+                    dischargingMagSafeLEDState = UInt8(clamping: intVal)
+                }
             case "heatProtectionMagSafeLEDState":
-                heatProtectionMagSafeLEDState = UInt8(value as? Int ?? Int(heatProtectionMagSafeLEDState))
+                if let intVal = value as? Int {
+                    heatProtectionMagSafeLEDState = UInt8(clamping: intVal)
+                }
             default:
                 logger.warning("Unknown setting key: \(key)")
             }

--- a/ChargingHelper/main.swift
+++ b/ChargingHelper/main.swift
@@ -40,9 +40,9 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        // Construct the requirement: identifier "com.dinanathdash.stasis"
+        // Construct the requirement: identifier "com.dinanathdash.stasis" and Team ID
         var requirement: SecRequirement?
-        let reqString = "identifier \"com.dinanathdash.stasis\"" as CFString
+        let reqString = "anchor apple generic and identifier \"com.dinanathdash.stasis\" and (certificate leaf[subject.OU] = \"63P4XT247T\" or certificate leaf[subject.CN] = \"Apple Development: dashdinanath056@gmail.com (63P4XT247T)\")" as CFString
         let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
         guard reqStatus == errSecSuccess, let validReq = requirement else {
             logger.error("Failed to create SecRequirement")

--- a/ChargingHelper/main.swift
+++ b/ChargingHelper/main.swift
@@ -80,7 +80,11 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
         newConnection.exportedObject = helper
 
         newConnection.invalidationHandler = {
-            logger.info("XPC connection invalidated, but daemon stays alive")
+            logger.info("XPC connection invalidated. Resetting to safe defaults and stopping power events.")
+            Task { @MainActor in
+                ChargingPowerState.restoreDefaults()
+                ChargingPowerEvents.stop()
+            }
         }
 
         newConnection.resume()

--- a/ChargingHelper/main.swift
+++ b/ChargingHelper/main.swift
@@ -40,9 +40,9 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        // Construct the requirement: identifier "com.dinanathdash.Stasis"
+        // Construct the requirement: identifier "com.dinanathdash.stasis"
         var requirement: SecRequirement?
-        let reqString = "identifier \"com.dinanathdash.Stasis\"" as CFString
+        let reqString = "identifier \"com.dinanathdash.stasis\"" as CFString
         let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
         guard reqStatus == errSecSuccess, let validReq = requirement else {
             logger.error("Failed to create SecRequirement")

--- a/ChargingHelper/main.swift
+++ b/ChargingHelper/main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import os.log
 import smc_power
 
@@ -28,12 +29,39 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
         _ listener: NSXPCListener,
         shouldAcceptNewConnection newConnection: NSXPCConnection
     ) -> Bool {
+        // Validate the code signature of the connecting process
+        let pid = newConnection.processIdentifier
+        let attributes = [kSecGuestAttributePid: pid] as CFDictionary
+
+        var code: SecCode?
+        let status = SecCodeCopyGuestWithAttributes(nil, attributes, [], &code)
+        guard status == errSecSuccess, let validCode = code else {
+            logger.error("Failed to get SecCode for connecting process PID \(pid) (status: \(status))")
+            return false
+        }
+
+        // Construct the requirement: identifier "com.dinanathdash.Stasis"
+        var requirement: SecRequirement?
+        let reqString = "identifier \"com.dinanathdash.Stasis\"" as CFString
+        let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
+        guard reqStatus == errSecSuccess, let validReq = requirement else {
+            logger.error("Failed to create SecRequirement")
+            return false
+        }
+
+        // Check validity against the requirement
+        let checkStatus = SecCodeCheckValidity(validCode, [], validReq)
+        guard checkStatus == errSecSuccess else {
+            logger.error("XPC connection rejected: Process does not match required code signature (status: \(checkStatus))")
+            return false
+        }
+
+        logger.info("XPC connection accepted from valid Stasis process")
+
         newConnection.exportedInterface = NSXPCInterface(
             with: (any ChargingHelperProtocol).self
         )
         newConnection.exportedObject = helper
-
-        logger.info("XPC connection accepted")
 
         newConnection.invalidationHandler = {
             logger.info("XPC connection invalidated, but daemon stays alive")

--- a/ChargingHelper/main.swift
+++ b/ChargingHelper/main.swift
@@ -40,9 +40,25 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        // Construct the requirement: identifier "com.dinanathdash.stasis" and Team ID
+        // Dynamically build requirement matching our own signing certificate's Common Name
+        var selfCode: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(rawValue: 0), &selfCode) == errSecSuccess,
+              let code = selfCode else { return false }
+        
+        var dict: CFDictionary?
+        let staticCode = unsafeBitCast(code, to: SecStaticCode.self)
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &dict) == errSecSuccess,
+              let info = dict as? [String: Any],
+              let certs = info[kSecCodeInfoCertificates as String] as? [SecCertificate],
+              let leaf = certs.first else { return false }
+        
+        var cnCF: CFString?
+        SecCertificateCopyCommonName(leaf, &cnCF)
+        guard let commonName = cnCF as String? else { return false }
+        
+        let reqString = "anchor apple generic and identifier \"com.dinanathdash.stasis\" and certificate leaf[subject.CN] = \"\(commonName)\"" as CFString
+        
         var requirement: SecRequirement?
-        let reqString = "anchor apple generic and identifier \"com.dinanathdash.stasis\" and (certificate leaf[subject.OU] = \"63P4XT247T\" or certificate leaf[subject.CN] = \"Apple Development: dashdinanath056@gmail.com (63P4XT247T)\")" as CFString
         let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
         guard reqStatus == errSecSuccess, let validReq = requirement else {
             logger.error("Failed to create SecRequirement")

--- a/Helper/main.swift
+++ b/Helper/main.swift
@@ -19,9 +19,25 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        // Construct the requirement: identifier "com.dinanathdash.stasis" and Team ID
+        // Dynamically build requirement matching our own signing certificate's Common Name
+        var selfCode: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(rawValue: 0), &selfCode) == errSecSuccess,
+              let code = selfCode else { return false }
+        
+        var dict: CFDictionary?
+        let staticCode = unsafeBitCast(code, to: SecStaticCode.self)
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &dict) == errSecSuccess,
+              let info = dict as? [String: Any],
+              let certs = info[kSecCodeInfoCertificates as String] as? [SecCertificate],
+              let leaf = certs.first else { return false }
+        
+        var cnCF: CFString?
+        SecCertificateCopyCommonName(leaf, &cnCF)
+        guard let commonName = cnCF as String? else { return false }
+        
+        let reqString = "anchor apple generic and identifier \"com.dinanathdash.stasis\" and certificate leaf[subject.CN] = \"\(commonName)\"" as CFString
+        
         var requirement: SecRequirement?
-        let reqString = "anchor apple generic and identifier \"com.dinanathdash.stasis\" and (certificate leaf[subject.OU] = \"63P4XT247T\" or certificate leaf[subject.CN] = \"Apple Development: dashdinanath056@gmail.com (63P4XT247T)\")" as CFString
         let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
         guard reqStatus == errSecSuccess, let validReq = requirement else {
             return false

--- a/Helper/main.swift
+++ b/Helper/main.swift
@@ -19,9 +19,9 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        // Construct the requirement: identifier "com.dinanathdash.Stasis"
+        // Construct the requirement: identifier "com.dinanathdash.stasis"
         var requirement: SecRequirement?
-        let reqString = "identifier \"com.dinanathdash.Stasis\"" as CFString
+        let reqString = "identifier \"com.dinanathdash.stasis\"" as CFString
         let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
         guard reqStatus == errSecSuccess, let validReq = requirement else {
             return false

--- a/Helper/main.swift
+++ b/Helper/main.swift
@@ -19,9 +19,9 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        // Construct the requirement: identifier "com.dinanathdash.stasis"
+        // Construct the requirement: identifier "com.dinanathdash.stasis" and Team ID
         var requirement: SecRequirement?
-        let reqString = "identifier \"com.dinanathdash.stasis\"" as CFString
+        let reqString = "anchor apple generic and identifier \"com.dinanathdash.stasis\" and (certificate leaf[subject.OU] = \"63P4XT247T\" or certificate leaf[subject.CN] = \"Apple Development: dashdinanath056@gmail.com (63P4XT247T)\")" as CFString
         let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
         guard reqStatus == errSecSuccess, let validReq = requirement else {
             return false

--- a/Helper/main.swift
+++ b/Helper/main.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Security
+
 
 class ServiceDelegate: NSObject, NSXPCListenerDelegate {
     let helper = Helper()
@@ -7,6 +9,30 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
         _ listener: NSXPCListener,
         shouldAcceptNewConnection newConnection: NSXPCConnection
     ) -> Bool {
+        // Validate the code signature of the connecting process
+        let pid = newConnection.processIdentifier
+        let attributes = [kSecGuestAttributePid: pid] as CFDictionary
+
+        var code: SecCode?
+        let status = SecCodeCopyGuestWithAttributes(nil, attributes, [], &code)
+        guard status == errSecSuccess, let validCode = code else {
+            return false
+        }
+
+        // Construct the requirement: identifier "com.dinanathdash.Stasis"
+        var requirement: SecRequirement?
+        let reqString = "identifier \"com.dinanathdash.Stasis\"" as CFString
+        let reqStatus = SecRequirementCreateWithString(reqString, [], &requirement)
+        guard reqStatus == errSecSuccess, let validReq = requirement else {
+            return false
+        }
+
+        // Check validity against the requirement
+        let checkStatus = SecCodeCheckValidity(validCode, [], validReq)
+        guard checkStatus == errSecSuccess else {
+            return false
+        }
+
         newConnection.exportedInterface = NSXPCInterface(
             with: (any HelperProtocol).self
         )


### PR DESCRIPTION
This pull request introduces stricter validation for XPC connections by enforcing code signature checks, and also improves the robustness of settings validation in the `ChargingSettings` enum. The main changes are focused on enhancing security and ensuring that only properly signed processes can establish XPC connections, as well as clamping and validating user-provided settings to safe ranges.

**Security improvements for XPC connections:**

* Both `ChargingHelper/main.swift` and `Helper/main.swift` now validate the code signature of the connecting process in `shouldAcceptNewConnection`, ensuring only processes signed with the same certificate and bundle identifier (`com.dinanathdash.stasis`) are accepted. This is done by dynamically building a requirement based on the current process's signing certificate and comparing it to the connecting process. [[1]](diffhunk://#diff-1c8e79bf4e6a75409e7cdcb9627c529afdec239d3eb3a6ba564ba5b80beffb1dR32-L37) [[2]](diffhunk://#diff-53ef855a8014afe0f4d59a852a0734039f799560044a243a925b97feb254e196R12-R51)
* The `Security` framework is imported in both main files to support this validation. [[1]](diffhunk://#diff-1c8e79bf4e6a75409e7cdcb9627c529afdec239d3eb3a6ba564ba5b80beffb1dR2) [[2]](diffhunk://#diff-53ef855a8014afe0f4d59a852a0734039f799560044a243a925b97feb254e196R2-R3)

**Settings validation improvements:**

* In `ChargingSettings.swift`, the assignment for several settings now clamps or bounds values to safe ranges:
  - `chargeLimit` is clamped between 50 and 100.
  - `sailingModeLimit` is clamped between 1 and 100.
  - `heatProtectionLimit` is clamped between 20 and 60.
  - All MagSafe LED state values are clamped to the valid `UInt8` range.
  This helps prevent invalid or unsafe configuration values from being set.
  
Fixes #37 